### PR TITLE
update erchef to use new mini_s3 config values in chef_common

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/erchef.config.erb
@@ -34,10 +34,11 @@
 
                 %% We need this parameter in chef_common now, too
                 {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
-                
+
                 {s3_access_key_id, "<%= node['private_chef']['aws']['aws_key'] %>"},
                 {s3_secret_key_id, "<%= node['private_chef']['aws']['aws_secret'] %>"},
-                {s3_url, "http://s3.amazonaws.com"},
+                %% this is hard-coded until bookshelf gets integrated.
+                {s3_url, "https://s3.amazonaws.com"},
                 {s3_platform_bucket_name, "<%= node['private_chef']['aws']['s3_bucket'] %>"},
 
                 {solr_url, "http://<%= node['private_chef']['opscode-solr']['vip'] %>:<%= node['private_chef']['opscode-solr']['port'] %>/solr"},


### PR DESCRIPTION
This small pull-request is mainly here to update erchef app.config to use mini_s3 config values.

THAR BE DRAGONS - This requires merging of
https://github.com/opscode/chef-api-common-erlang/pull/41
