### PR TITLE
[OC-2379] Prevent rendering of google analytics javascript snippet.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/opscode-webui-config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/opscode-webui-config.rb.erb
@@ -5,7 +5,7 @@ Chef::Config[:chef_server_host_uri]  = 'http://<%= node['private_chef']['lb_inte
 Chef::Config[:web_ui_proxy_user]     = 'pivotal'
 Chef::Config[:web_ui_private_key]    = '/etc/opscode/webui_priv.pem'
 Chef::Config[:job_worker_public_key] = '/etc/opscode/worker-public.pem'
-Chef::Config[:google_analytics_id]   = ''
+Chef::Config[:google_analytics_id]   = false
 
 ##
 ## TODO: the chargify config values are environment dependent - set the environments up with chargify
@@ -68,5 +68,3 @@ OpscodeWebui::Application.configure do
 
 
 end
-
-


### PR DESCRIPTION
Setting Chef::Config[:google_analytics_id] to false will prevent
the javascript snippet from being rendered on the management console
login page.  This snippet sent an HTTP GET to Google.
