### PR TITLE
Control Jetty Log Retention

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -75,6 +75,13 @@ default['private_chef']['rabbitmq']['vip'] = '127.0.0.1'
 default['private_chef']['rabbitmq']['consumer_id'] = 'hotsauce'
 
 ####
+# Jetty dummy for logs
+####
+# Should always be enable = false, we control Jetty+Solr through opscode-solr
+default['private_chef']['jetty']['enable'] = false
+default['private_chef']['jetty']['ha'] = false
+
+####
 # Chef Solr
 ####
 default['private_chef']['opscode-solr']['enable'] = true
@@ -570,6 +577,7 @@ default['private_chef']['logs']['log_retention'] = {
   "opscode-certificate" => 14,
   "opscode-account" => 14,
   "opscode-solr" => 14,
+  "jetty" => 14,
   "opscode-expander" => 14,
   "opscode-org-creator" => 14,
   "opscode-chef" => 14,

--- a/files/private-chef-cookbooks/private-chef/recipes/log_cleanup.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/log_cleanup.rb
@@ -8,7 +8,7 @@
 commands = []
 
 node['private_chef']['logs']['log_retention'].each do |service, days|
-  next unless node['private_chef'][service]['enable']
+  next unless node['private_chef'][service]['enable'] || service == "jetty"
   log_directory = node['private_chef'][service]['log_directory']
   commands << "find #{log_directory} -type f \\( -mtime +#{days} \\! -name config \\! -name lock \\! -name state \\! -name newstate \\) -print0 1>&2 | xargs -0 rm -f"
 end

--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-solr.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-solr.rb
@@ -66,7 +66,7 @@ template File.join(solr_jetty_dir, "etc", "jetty.xml") do
   owner node['private_chef']['user']['username']
   mode "0644"
   source "jetty.xml.erb"
-  variables(node['private_chef']['opscode-solr'].to_hash)
+  variables(node['private_chef']['opscode-solr'].to_hash.merge(node['private_chef']['logs'].to_hash))
   notifies :restart, 'service[opscode-solr]' if should_notify
 end
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/jetty.xml.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/jetty.xml.erb
@@ -193,8 +193,8 @@
     <Ref id="RequestLog">
       <Set name="requestLog">
         <New id="RequestLogImpl" class="org.mortbay.jetty.NCSARequestLog">
-          <Arg><SystemProperty name="jetty.logs" default="./logs"/>/yyyy_mm_dd.request.log</Arg>
-          <Set name="retainDays">90</Set>
+          <Arg><SystemProperty name="jetty.logs" default="<%= @log_directory %>"/>/yyyy_mm_dd.jetty.request.log</Arg>
+          <Set name="retainDays"><%= @log_retention['jetty'] %></Set>
           <Set name="append">true</Set>
           <Set name="extended">false</Set>
           <Set name="LogTimeZone">GMT</Set>


### PR DESCRIPTION
Controls retention of jetty logfiles for https://tickets.corp.opscode.com/browse/OC-1624 and https://tickets.corp.opscode.com/browse/OC-1625. Rotation is handled by Jetty itself
