### PR TITLE
Jc/rename authz flags

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -384,10 +384,12 @@ default['private_chef']['opscode-authz']['vip'] = '127.0.0.1'
 default['private_chef']['opscode-authz']['superuser_id'] = '5ca1ab1ef005ba111abe11eddecafbad'
 default['private_chef']['opscode-authz']['couchdb_max_conn'] = '100'
 
+default['private_chef']['opscode-authz']['custom_acls_always_for_modification'] = true
 default['private_chef']['opscode-authz']['custom_acls_cookbooks'] = true
 default['private_chef']['opscode-authz']['custom_acls_data'] = true
 default['private_chef']['opscode-authz']['custom_acls_depsolver'] = true
 default['private_chef']['opscode-authz']['custom_acls_roles'] = true
+
 
 ###
 # Opscode Certificate

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -25,6 +25,9 @@
               %% how many nodes are deserialized at a time in
               %% preparing a response.
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
+
+              {custom_acls_always_for_modification, <%= node['private_chef']['opscode-authz']['custom_acls_always_for_modification'] %>},
+
               {custom_acls_depsolver, <%= node['private_chef']['opscode-authz']['custom_acls_depsolver'] %>},
               {custom_acls_data, <%= node['private_chef']['opscode-authz']['custom_acls_data'] %>},
               {custom_acls_cookbooks, <%= node['private_chef']['opscode-authz']['custom_acls_cookbooks'] %>},


### PR DESCRIPTION
- Renamed to custom_acls_*
- Added 'custom_acls_always_for_modification' configuration flag.
  Defaults to true, and when true means that we always use custom ACLs
  for non-GET methods regardless of the setting of custom_acls_FOO
  settings. This trades some performance for better security.
