### PR TITLE
Upgrade postgres to 9.1.6

### DIFF
--- a/config/patches/postgresql/postgresql-9.1.6-configure-ncurses-fix.patch
+++ b/config/patches/postgresql/postgresql-9.1.6-configure-ncurses-fix.patch
@@ -1,0 +1,11 @@
+--- postgresql-9.1.6/configure  2012-09-19 14:50:31.000000000 -0700
++++ postgresql-9.1.6.fixed/configure    2012-10-01 14:57:04.000000000 -0700
+@@ -8391,7 +8391,7 @@
+ else   READLINE_ORDER="-ledit -lreadline"
+ fi
+ for pgac_rllib in $READLINE_ORDER ; do
+-  for pgac_lib in "" " -ltermcap" " -lncurses" " -lcurses" ; do
++  for pgac_lib in "" " -lncurses" " -lcurses" ; do
+     LIBS="${pgac_rllib}${pgac_lib} $pgac_save_LIBS"
+     cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -1,15 +1,15 @@
 name "postgresql"
-version "9.1.2"
+version "9.1.6"
 
 dependencies ["zlib",
               "openssl",
               "readline",
               "ncurses"]
 
-source :url => "http://ftp.postgresql.org/pub/source/v9.1.2/postgresql-9.1.2.tar.gz",
-       :md5 => "fe01293f96e04da9879840b1996a3d2c"
+source :url => "http://ftp.postgresql.org/pub/source/v9.1.6/postgresql-9.1.6.tar.gz",
+       :md5 => "d04593edd0c0b724a8eaad91bf4d7093"
 
-relative_path "postgresql-9.1.2"
+relative_path "postgresql-9.1.6"
 
 configure_env = {
   "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
@@ -18,7 +18,7 @@ configure_env = {
 }
 
 build do
-  patch :source => 'postgresql-9.1.2-configure-ncurses-fix.patch'
+  patch :source => 'postgresql-9.1.6-configure-ncurses-fix.patch'
   command ["./configure",
            "--prefix=#{install_dir}/embedded",
            "--with-openssl --with-includes=#{install_dir}/embedded/include",

--- a/files/private-chef-upgrades/001/007_postgres_9_1_6.rb
+++ b/files/private-chef-upgrades/001/007_postgres_9_1_6.rb
@@ -1,0 +1,4 @@
+define_upgrade do
+  upgrade_schema_to 25
+  restart_service "postgres"
+end


### PR DESCRIPTION
This contains the necessary migration steps to upgrade postgres to 9.1.6.

*\* We need to make sure that we pick the corresponding changes for chef-sql-schema (branch postgres-9.1.6-migration) while creating a new deb.

*\* Also these changes are applied over gzipnode schema changes.

Tested with creating a new deb with omnibus, private-chef-ctl upgrade from an earlier version, and private-chef-ctl test on the upgraded box.

Sending this PR to uncle-ned branch for the fix to be included in subsequent releases to FB (not the first Tuesday release).
