### PR TITLE
Temporarily Pend Runlist and '@' Search Tests

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -136,3 +136,5 @@ ruby_data_endpoint? true
 ruby_role_endpoint? true
 ruby_cookbook_endpoint? true
 ruby_client_endpoint? true
+
+old_runlists_and_search true


### PR DESCRIPTION
Temporarily pend tests for runlist normalization and search queries
with '@' characters.  These features will be in the next release of
Erchef, but we want to be able to have a passing test suite until
then.  This only really affects mixed Ruby / Erlang Private Chef
builds, though.  Tests are pending depending on the presence of a
Pedant config setting; absence of the setting means the tests will run
normally.
