### PR TITLE
OC-4709: Add server api version header

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -8,7 +8,9 @@
 ###
 # High level options
 ###
-default['private_chef']['version'] = "11.0.0"
+default['private_chef']['api_version'] = "11.0.0"
+default['private_chef']['flavor'] = "opc"
+
 default['private_chef']['notification_email'] = "pc-default@opscode.com"
 default['private_chef']['from_email'] = '"Opscode" <donotreply@opscode.com>'
 default['private_chef']['database_type'] = "postgresql"

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -17,8 +17,11 @@
                          {file_size, 50}]]}
             ]},
  {oc_chef_wm, [
-              {ip, "<%= @listen %>"},
-              {port, <%= @port %>},
+               {api_version, "<%= node['private_chef']['api_version'] %>"},
+               {server_flavor, "<%= node['private_chef']['flavor'] %>"},
+
+               {ip, "<%= @listen %>"},
+               {port, <%= @port %>},
               {reqid_header_name, "X-Request-Id"},
               {auth_skew, <%= @auth_skew %>},
               %% currently only used by the search endpoint to bound


### PR DESCRIPTION
This adds an X-Ops-API-Info header to Erchef server responses.

It contains the "flavor" of server (i.e. "osc" or "opc"), the logical
server version (e.g. "11.0.0" for upcoming Chef 11), and the OTP
version of the Erchef release (mainly useful for debugging).

An example:

```
vagrant@open-source-chef:/srv/piab/mounts/erchef$ curl -I 127.0.0.1:8000/nodes
HTTP/1.1 405 Method Not Allowed
X-Ops-API-Info: flavor=osc;version=11.0.0;erchef=1.0.9
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Date: Wed, 21 Nov 2012 02:37:36 GMT
Content-Length: 0
Allow: GET, POST
```

(quick-and-dirty test with an unauthenticated request, but you get the picture.)

This has been confirmed on Omnibus builds of both Erchef servers.
