### PR TITLE
md/oc2594 node count in status endpoint

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -87,6 +87,7 @@ http {
 
     # pushy
     <%= @helper.pushy_api("^/organizations/[a-z0-9\-_]+?/pushy") %>
+    <%= @helper.pushy_api("^/_status") %>
 
     # search requests
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/(?:search)/.+$") %>

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
@@ -57,6 +57,7 @@
 
     # pushy
     <%= @helper.pushy_api("^/organizations/[a-z0-9\-_]+?/pushy/{0,1}") %>
+    <%= @helper.pushy_api("^/_status") %>
 
     # search requests
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/(?:search)/.+$") %>


### PR DESCRIPTION
Added the number of nodes currently active to the _status endpoint. A future refactor will maybe retrieve these values from folsom.

https://github.com/opscode/oc-pushy-pedant/pull/6
https://github.com/opscode/opscode-pushy-server/pull/61
