### PR TITLE
md/oc5393 make _status endpoint available via curl

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -89,7 +89,7 @@ http {
     <%= @helper.pushy_api("^/organizations/[a-z0-9\-_]+?/pushy") %>
 
     # pushy status endpoint
-    location ~ "^/_status$" {
+    location ~ "^/pushy/_status$" {
         set $my_upstream opscode_pushy;
         proxy_redirect http://$my_upstream /;
         proxy_pass http://$my_upstream;

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
@@ -59,7 +59,7 @@
     <%= @helper.pushy_api("^/organizations/[a-z0-9\-_]+?/pushy/{0,1}") %>
 
     # pushy status endpoint
-    location ~ "^/_status$" {
+    location ~ "^/pushy/_status$" {
         set $my_upstream opscode_pushy;
         proxy_redirect http://$my_upstream /;
         proxy_pass http://$my_upstream;


### PR DESCRIPTION
You can now access the _status enpoint using curl -k

https://github.com/opscode/oc-pushy-pedant/pull/8
https://github.com/opscode/opscode-pushy-server/pull/67
