### PR TITLE
cron_cmd tighten up

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/couchdb.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/couchdb.rb
@@ -71,8 +71,8 @@ end
 
 # Add it to cron
 cron_email = node['private_chef']['notification_email']
-cron_cmd = "if `test -d #{couchdb_data_dir}` ; then #{compact_script_command} 2>&1 > #{couchdb_log_dir}/compact-`date \"+%Y%m%d%H%M%S\"`.log ; fi"
-cron_cmd_major_offenders = "if `test -d #{couchdb_data_dir}` ; then #{compact_script_command} --max-dbs=50 2>&1 > #{couchdb_log_dir}/compact-`date \"+\\%Y\\%m\\%d\\%H\\%M\\%S\"`.log ; fi"
+cron_cmd = "if `test -e #{couchdb_data_dir}/_users.couch` ; then #{compact_script_command} 2>&1 > #{couchdb_log_dir}/compact-`date \"+\\%Y\\%m\\%d\\%H\\%M\\%S\"`.log ; fi"
+cron_cmd_major_offenders = "if `test -e #{couchdb_data_dir}/_users.couch` ; then #{compact_script_command} --max-dbs=50 2>&1 > #{couchdb_log_dir}/compact-`date \"+\\%Y\\%m\\%d\\%H\\%M\\%S\"`.log ; fi"
 
 template "/etc/cron.d/couchdb_compact" do
   source "compact-cron-entry.erb"


### PR DESCRIPTION
1. escape % in couchdb compact cron job datestamped logfile name part 2
2. Should not run couchdb cronjobs as a secondary backend
