### PR TITLE
OC-3471 Rename chef_authz -> oc_chef_authz

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -35,7 +35,7 @@
   {chef_wm, [
              {server_version, "<%= node['private_chef']['version'] %>"},
              {health_ping_timeout, 400},
-             {health_ping_modules, [chef_authz, chef_otto, chef_sql, chef_solr]}
+             {health_ping_modules, [oc_chef_authz, chef_otto, chef_sql, chef_solr]}
             ]},
   {chef_authn, [
                 {keyring, [{default, "/etc/opscode/webui_pub.pem"}]}


### PR DESCRIPTION
The oc_chef_authz repo has been created and loaded with what should be
the full history of chef_authz. The code modules have been renamed so
that the modules match the repository name.

oc_chef_wm code updated for the search and replace operation.
Similarly, opscode-omnibus updated for the name change.

The changes in oc_erchef will allow you to test this set of changes if
desired, however, I don't plan to merge that directly. Had some
trouble with version conflicts and want to see what happens when the
rest of the code is on master and we build an oc_erchef release.

This PR also includes a merge for chef_authz that replaces all code
with a single README explaining what happened for master. Have not
touched the release branch. Before chef_authz can be further removed,
the reporting project will need to update.
