### PR TITLE
Update OPC for new stats_hero

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -199,6 +199,7 @@ default['private_chef']['opscode-erchef']['couchdb_max_conn'] = '100'
 default['private_chef']['opscode-erchef']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 default['private_chef']['opscode-erchef']['s3_bucket'] = 'bookshelf'
+default['private_chef']['opscode-erchef']['root_metric_key'] = "chefAPI"
 
 ####
 # Chef Server WebUI

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -30,7 +30,9 @@
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
               {estatsd_server, "<%= node['private_chef']['estatsd']['vip'] %>"},
               {estatsd_port, <%= node['private_chef']['estatsd']['port'] %>},
-              {superusers, [<<"pivotal">>]}
+              {superusers, [<<"pivotal">>]},
+              %% metrics config
+              {root_metric_key, "<%= @root_metric_key %>"}
              ]},
   {chef_wm, [
              {server_version, "<%= node['private_chef']['version'] %>"},


### PR DESCRIPTION
Similar to the changes in chef_wm, add support for new metrics config
and stats_hero worker config into oc_chef_wm.

Add config for metrics into opscode-omnibus.
