### PR TITLE
10.16 compat fix: use simple provider for runit instead of init

### DIFF
--- a/files/private-chef-cookbooks/runit/definitions/runit_service.rb
+++ b/files/private-chef-cookbooks/runit/definitions/runit_service.rb
@@ -182,7 +182,7 @@ define :runit_service, :directory => nil, :only_if => false, :finish_script => f
       if params[:owner]
         control_cmd = "#{node[:runit][:chpst_bin]} -u #{params[:owner]} #{control_cmd}"
       end
-      provider Chef::Provider::Service::Init
+      provider Chef::Provider::Service::Simple
       supports :restart => true, :status => true
       start_command "#{control_cmd} #{params[:start_command]} #{service_dir_name}"
       stop_command "#{control_cmd} #{params[:stop_command]} #{service_dir_name}"


### PR DESCRIPTION
@schisamo could you take a quick look?  we were running into a breakage using 10.16 to upgrade because services weren't accessible vi /etc/init.d due to assumptions introduced for whyrun support. Changing to simple service provider corrects it.  
