### PR TITLE
[OC-5591] properly enable _status endpoints

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -88,13 +88,6 @@ http {
     # pushy
     <%= @helper.pushy_api("^/organizations/[a-z0-9\-_]+?/pushy") %>
 
-    # pushy status endpoint
-    location ~ "^/pushy/_status$" {
-        set $my_upstream opscode_pushy;
-        proxy_redirect http://$my_upstream /;
-        proxy_pass http://$my_upstream;
-    }
-
     # search requests
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/(?:search)/.+$") %>
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/(?:search)/?$") %>

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
@@ -45,6 +45,20 @@
       proxy_pass http://bookshelf;
     }
 
+    # erchef status endpoint
+    location ~ "/_status/?$" {
+      types { }
+      default_type application/json;
+      proxy_pass http://opscode_erchef;
+    }
+
+    # pushy status endpoint
+    location ~ "^/pushy/_status/?$" {
+      types { }
+      default_type application/json;
+      proxy_pass http://opscode_pushy;
+    }
+
     # This internal location is used to serve checksum file content
     # via the X-Accel-Redirect header. See http://wiki.nginx.org/XSendfile
     location /checksum/ {
@@ -57,13 +71,6 @@
 
     # pushy
     <%= @helper.pushy_api("^/organizations/[a-z0-9\-_]+?/pushy/{0,1}") %>
-
-    # pushy status endpoint
-    location ~ "^/pushy/_status$" {
-        set $my_upstream opscode_pushy;
-        proxy_redirect http://$my_upstream /;
-        proxy_pass http://$my_upstream;
-    }
 
     # search requests
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/(?:search)/.+$") %>
@@ -106,7 +113,6 @@
                               node['private_chef']['opscode-chef']['upload_proto']) %>
 
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/status/{0,1}.*$", :ruby) %>
-    <%= @helper.chef_api("^/_status") %>
 
     # opscode reporting endpoints
     <%= @helper.reporting_api("^/organizations/[a-z0-9\-_]+?/reports/.*$") %>


### PR DESCRIPTION
- ensure _status endpoints don't require HTTP_X_OPS_USERID to be set
- only expose _status endpoints on external LB
- ensure default_type for _status endpoints is properly set to 
  `application/json`
