### PR TITLE
Keep opscode-chef enabled on backend.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -289,7 +289,6 @@ module PrivateChef
       PrivateChef["opscode_webui"]["worker_processes"] ||= 2
       PrivateChef["postgresql"]["listen_address"] ||= "0.0.0.0"
       PrivateChef["postgresql"]["md5_auth_cidr_addresses"] ||= ["0.0.0.0/0", "::0/0"]
-      PrivateChef["opscode_chef"]["enable"] ||= false
       PrivateChef["redis"]["bind"] ||= "0.0.0.0"
       PrivateChef["opscode_account"]["worker_processes"] ||= 4
       if bootstrap


### PR DESCRIPTION
opscode-chef was originally disabled everywhere when creating an
opscode-erchef build of OPC.  The following commit attempted to rever
this change:

commit 37b75f07dceeaff957ed026ffe7d48c8a24cf219
Author: Seth Chisamore schisamo@opscode.com
Date:   Thu Oct 11 15:14:46 2012 -0400

```
Revert "opscode-chef should be disabled by default everywhere."

This reverts commit b81e2a7b61cfc9a7d1ebab5d54a5b70338daa5fb.
```

Unfortunately, the original change was done over a series of commits
and the single reversion above left us in a slightly mis-configured
state.
