### PR TITLE
OC-5466: Remove mysql support from OSC

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -86,7 +86,7 @@
            {db_pass, "<%= node['private_chef'][node['private_chef']['database_type']]['sql_password'] %>"},
            {db_name, "opscode_chef" },
 
-           {prepared_statements, {chef_sql, opc_statements, [<%= node['private_chef']['database_type'] == "postgresql" ? "pgsql" : "mysql" %>]}},
+           {prepared_statements, {oc_chef_sql, statements, [<%= node['private_chef']['database_type'] == "postgresql" ? "pgsql" : "mysql" %>]}},
            {column_transforms,
            <%-if node['private_chef']['database_type'] == "mysql" %>
                               [{<<"frozen">>,


### PR DESCRIPTION
Use oc_chef_sql:statements/1 to populate OPC queries (instead of chef_sql:statements/0)

Related:
- https://github.com/opscode/oc_chef_wm/pull/27
- https://github.com/opscode/chef_db/pull/28
