### PR TITLE
Change the password based on the observation that mysql-5.1 does not acc...

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -109,7 +109,7 @@ module PrivateChef
       PrivateChef['rabbitmq']['password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['jobs_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['opscode_webui']['cookie_secret'] ||= generate_hex_if_bootstrap(50, ha_guard)
-      PrivateChef['mysql']['sql_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
+      PrivateChef['mysql']['sql_password'] ||= generate_hex_if_bootstrap(39, ha_guard)
       PrivateChef['postgresql']['sql_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['postgresql']['sql_ro_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['opscode_account']['session_secret_key'] ||= generate_hex_if_bootstrap(50, ha_guard)


### PR DESCRIPTION
...ept passwords > 80 characters. The SecureRandom generator generates random numbers twice the specified seed.

So I have decreesed the seed to the SecureRandon Generator. Tested this out by building a new deb - vm and trying to change db to mysql with the generated password - and it works.
