### PR TITLE
Add search result caching

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -201,6 +201,9 @@ default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 default['private_chef']['opscode-erchef']['s3_bucket'] = 'bookshelf'
 default['private_chef']['opscode-erchef']['s3_url_ttl'] = 900
 default['private_chef']['opscode-erchef']['root_metric_key'] = "chefAPI"
+default['private_chef']['opscode-erchef']['eredis_client_pool_size'] = 3
+default['private_chef']['opscode-erchef']['redis_db'] = 6
+default['private_chef']['opscode-erchef']['search_cache_entry_ttl'] = 60
 
 ####
 # Chef Server WebUI

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -30,7 +30,13 @@
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
               {superusers, [<<"pivotal">>]},
               %% metrics config
-              {root_metric_key, "<%= @root_metric_key %>"}
+              {root_metric_key, "<%= @root_metric_key %>"},
+              %% search cache
+              {eredis_client_pool_size, <%= @eredis_client_pool_size %>},
+              {redis_host, "<%= node['private_chef']['redis']['vip'] %>"},
+              {redis_port, <%= node['private_chef']['redis']['port'] %>},
+              {redis_db, <%= @redis_db %>},
+              {search_cache_entry_ttl, <%= @search_cache_entry_ttl %>}
              ]},
   {chef_wm, [
              {server_version, "<%= node['private_chef']['version'] %>"},


### PR DESCRIPTION
These PRs add the ability to cache search results to reduce load on
backend dbs.

For chef_wm, the cache defaults to a no-op cache.
