### PR TITLE
Allow for an addon.d which contains upstreams and endpoints for addons like pushy

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -137,6 +137,14 @@ template File.join(nginx_etc_dir, "fastcgi.conf") do
   notifies :restart, 'service[nginx]' if OmnibusHelper.should_notify?("nginx")
 end
 
+template File.join(nginx_addon_dir, "README.md") do
+  source "nginx-addons.README.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+end
+
+
 runit_service "nginx" do
   down node['private_chef']['nginx']['ha']
   options({

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx-addons.README.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx-addons.README.erb
@@ -1,0 +1,21 @@
+Private Chef Addons
+===================
+
+This directory exists to allow addons to Private Chef to add upstreams and routing rules
+to the nginx configuration
+
+Included files
+-------------
+There are includes in the main Nginx configuration that match the following patterns:
+
+* `*_upstreams.conf`: Upstream definitions
+
+* `*_external.conf`: Routing rules for routes exposed via the external LB
+
+* `*_internal.conf`: Routing rules for routes exposed via the internal LB
+
+File Naming
+-----------
+Files are included in normal alphabetic ordering.  To ensure consistent ordering, each
+addon should use a 2 digit numeric prefix followed by the component name.  e.g for
+addon 'foo' we would have files named `10-foo_upstreams.conf`, `10-foo_external.conf`, etc.

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -119,6 +119,10 @@ http {
                               "opscode_webui",
                               node['private_chef']['opscode-chef']['upload_internal_proto']) %>
 
+    # Include internal routes for addons
+    include <%= node['private_chef']['nginx']['dir'] %>/etc/addon.d/*_internal.conf;
+
+
     location / {
       proxy_redirect http://opscode_chef /;
       proxy_pass http://opscode_chef;

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx_chef_api_lb.conf.erb
@@ -104,8 +104,8 @@
 
     <%= @helper.chef_api("^/organizations/[a-z0-9\-_]+?/status/{0,1}.*$", :ruby) %>
 
-    # Include endpoints for addons
-    include <%= node['private_chef']['nginx']['dir'] %>/etc/addon.d/*_endpoints.conf;
+    # Include external routes for addons
+    include <%= node['private_chef']['nginx']['dir'] %>/etc/addon.d/*_external.conf;
 
     # opscode-account service endpoints
     <%= @helper.account_api("^/organizations/[a-z0-9\-_]+?/clients/{0,1}.*$", 'couchdb_clients') %>


### PR DESCRIPTION
Add a new addon.d configuration directory for nginx

this can contain *_upstreams.conf, *_endpoints.conf that allow an addon to deploy their own upstream and endpoint definitions
