### PR TITLE
Remove reporting specific dark launch config.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -443,7 +443,7 @@ default['private_chef']['dark_launch']["couchdb_checksums"] = true
 default['private_chef']['dark_launch']["couchdb_environments"] = true
 default['private_chef']['dark_launch']["couchdb_clients"] = true
 default['private_chef']['dark_launch']["add_type_and_bag_to_items"] = true
-default['private_chef']['dark_launch']["node_run_history"] = false
+
 ###
 # Opscode Account
 ###

--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -42,6 +42,7 @@ module PrivateChef
   nginx Mash.new
   log_retention Mash.new
   log_rotation Mash.new
+  dark_launch Mash.new
 
   servers Mash.new
   backend_vips Mash.new
@@ -203,6 +204,7 @@ module PrivateChef
       results['private_chef']['logs'] = {}
       results['private_chef']['logs']['log_retention'] = PrivateChef['log_retention']
       results['private_chef']['logs']['log_rotation'] = PrivateChef['log_rotation']
+      results['private_chef']['dark_launch'] = PrivateChef['dark_launch']
       results
     end
 


### PR DESCRIPTION
Also add in ability to now set dark_launch variables in private-chef.rb.
The dark launch variables do not have to appear in the attributes, new ones
will get merged into the set
