### PR TITLE
Upgrade to webmachine 1.10.1 (and be compatible w/ Erlang R16)

### DIFF
--- a/config/software/bookshelf.rb
+++ b/config/software/bookshelf.rb
@@ -1,5 +1,5 @@
 name "bookshelf"
-version "0.2.1"
+version "0.2.2"
 
 dependencies ["erlang", "rebar", "rsync"]
 

--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-version "1.0.3"
+version "1.0.4"
 
 dependencies ["ruby",
               "bundler",

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-version "0.19.6"
+version "0.19.9"
 
 dependencies ["erlang", "rebar", "rsync"]
 


### PR DESCRIPTION
This multi-repo PR upgrades the webmachine (and bundled mochiweb)
version to 1.10.1. Among other fixes, the new versions of webmachine
and mochiweb no longer use parameterized modules, a feature which has
been removed from Erlang >= R16.

While, I've done some testing with R16B and things look good (and
despite the branch name) these patches upgrade wm and include a few
other compat fixes for R16, but erlang is left at R15B03 and things
work fine there too.

Note that the PR in opscode-omnibus is for testing only and will not
be merged.
