### PR TITLE
Update Vagrantfile with provionerless baseboxes and latest Chef Client

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,22 +17,22 @@ Vagrant.configure("2") do |config|
 
   config.vm.define 'ubuntu-10.04' do |c|
     c.vm.box = "opscode-ubuntu-10.04"
-    c.vm.box_url = "http://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_chef-11.2.0.box"
+    c.vm.box_url = "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box"
   end
 
   config.vm.define 'ubuntu-12.04' do |c|
-    c.vm.box = "canonical-ubuntu-12.04"
-    c.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box"
+    c.vm.box = "opscode-ubuntu-12.04"
+    c.vm.box_url = "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
   end
 
   config.vm.define 'centos-5' do |c|
-    c.vm.box = "opscode-centos-5.8"
-    c.vm.box_url = "http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.8_chef-11.2.0.box"
+    c.vm.box = "opscode-centos-5.9"
+    c.vm.box_url = "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box"
   end
 
   config.vm.define 'centos-6' do |c|
-    c.vm.box = "opscode-centos-6.3"
-    c.vm.box_url = "http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box"
+    c.vm.box = "opscode-centos-6.4"
+    c.vm.box_url = "https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box"
   end
 
   config.vm.provider :virtualbox do |vb|
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   end
 
   # Ensure a recent version of the Chef Omnibus packages are installed
-  config.omnibus.chef_version = "11.4.0"
+  config.omnibus.chef_version = "11.4.4"
 
   # Enable the berkshelf-vagrant plugin
   config.berkshelf.enabled = true


### PR DESCRIPTION
- Change the baseboxes to use the latest from bento. Instructions in this repo already tell you to install vagrant-omnibus, so they should work with no other changes.
- Change the Chef Client version to 11.4.4.
