### PR TITLE
Add makeselfinst script so self-extracting packaging works

### DIFF
--- a/package-scripts/private-chef/makeselfinst
+++ b/package-scripts/private-chef/makeselfinst
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Install a full private-chef
+#
+
+PROGNAME=`basename $0`
+INSTALLER_DIR=`dirname $0`
+DEST_DIR=/opt/opscode
+CONFIG_DIR=/etc/opscode
+USAGE="usage: $0"
+
+error_exit()
+{
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+# move the actual files into place
+rm -rf $DEST_DIR/* || error_exit "Cannot remove contents of $DEST_DIR"
+mkdir -p $DEST_DIR || error_exit "Cannot create $DEST_DIR"
+cp -R $INSTALLER_DIR $DEST_DIR || error_exit "Cannot install to $DEST_DIR"
+rm -f $DEST_DIR/$PROGNAME
+
+exit 0


### PR DESCRIPTION
Building and installing on a Mac will fail if this script is not present.
