### PR TITLE
Using new versions of pedant/erchef.

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-version "1.0.9"
+version "1.0.10"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-version "0.20.0"
+version "0.20.1"
 
 dependency "erlang"
 dependency "rebar"


### PR DESCRIPTION
Updating for 7951 which includes the 503 consistency implementation for Private/Open Source.  Previously, if the named_sandbox was unfinished, a 400 was returned.  Now a 503 is returned allowing for chef client to retry.

Passing Build:

http://andra.ci.opscode.us/job/private-chef-build/202/downstreambuildview/?
