### PR TITLE
[sh/OC-7126] Rotate nginx nicely

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/logrotate-opscode.conf
+++ b/files/private-chef-cookbooks/private-chef/templates/default/logrotate-opscode.conf
@@ -7,6 +7,13 @@
   compress
   notifempty
   create 644 <%= attrs['owner'] || "root" %> <%= attrs['group'] || "root" %>
+<% if filespec.include?("nginx") %>
+  delaycompress
+  sharedscripts
+  postrotate
+    /opt/opscode/embedded/sbin/nginx -s reopen
+  endscript
+<% end %>
 }
 <% end %>
 


### PR DESCRIPTION
Previously, we did not send a USR1 signal to nginx while rotating it's logs. This made it very sad and resulted in a disk space leak. In a busy system, this would be a critical space leak.

This fix should be cherry picked and applied to builds for UncleNed, 1.2.8, and 1.4.x+
