### PR TITLE
[OC-7867] enable IPv6 support on external load balancer

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -300,6 +300,7 @@ default['private_chef']['nginx']['gzip_types'] = [ "text/plain", "text/css", "ap
 default['private_chef']['nginx']['keepalive_timeout'] = 65
 default['private_chef']['nginx']['client_max_body_size'] = '250m'
 default['private_chef']['nginx']['cache_max_size'] = '5000m'
+default['private_chef']['nginx']['enable_ipv6'] = false
 
 ###
 # MySQL

--- a/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
@@ -7,12 +7,17 @@ class NginxErb
   end
 
   def listen_port(proto)
-    case proto
-    when "http"
-      node['private_chef']['nginx']['non_ssl_port'] || 80
-    when "https"
-      node['private_chef']['nginx']['ssl_port']
-    end
+    listen_port = ""
+    listen_port << "[::]:" if node['private_chef']['nginx']['enable_ipv6']
+    listen_port << case proto
+                   when "http"
+                     node['private_chef']['nginx']['non_ssl_port'].to_s || "80"
+                   when "https"
+                     node['private_chef']['nginx']['ssl_port'].to_s
+                   else
+                     proto.to_s
+                   end
+    listen_port
   end
 
   def access_log(proto)

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -50,7 +50,7 @@ http {
         include <%= @chef_http_config %>;
       <%- else -%>
           server {
-            listen <%= @non_ssl_port %>;
+            listen <%= @helper.listen_port('http') %>;
             server_name <%= @server_name %>;
             access_log /var/log/opscode/nginx/rewrite-port-80.log;
             rewrite ^(.*) https://$server_name$1 permanent;
@@ -65,7 +65,7 @@ http {
   # internal lb config for Chef API Services
   <%- if node['private_chef']['lb_internal']['enable'] -%>
   server {
-    listen <%= node['private_chef']['lb_internal']['chef_port'] %>;
+    listen <%= @helper.listen_port(node['private_chef']['lb_internal']['chef_port']) %>;
     # The name doesn't matter; this is the only listener on this port
     server_name <%= node['fqdn'] %>;
 
@@ -138,7 +138,7 @@ http {
 
   # internal service access for opscode-account
   server {
-    listen <%= node['private_chef']['lb_internal']['account_port'] %>;
+    listen <%= @helper.listen_port(node['private_chef']['lb_internal']['account_port']) %>;
     # The name doesn't matter; this is the only listener on this port
     server_name <%= node['fqdn'] %>;
 
@@ -163,7 +163,7 @@ http {
 
   # internal service access for opscode-authz
   server {
-    listen <%= node['private_chef']['lb_internal']['authz_port'] %>;
+    listen <%= @helper.listen_port(node['private_chef']['lb_internal']['authz_port']) %>;
     server_name <%= node['fqdn'] %>;
 
     client_max_body_size <%= @client_max_body_size %>;
@@ -189,7 +189,7 @@ http {
   <%- if node['private_chef']['nagios']['enable'] -%>
   # nagios server
   server {
-    listen   <%= node['private_chef']['nagios']['port'] %>;
+    listen <%= @helper.listen_port(node['private_chef']['nagios']['port']) %>;
     server_name <%= node['fqdn'] %>;
 
     access_log /var/log/opscode/nginx/nagios.access.log;


### PR DESCRIPTION
We are already compiling IPv6 support into OpenResty with the 
`--with-ipv6` flag. This commit adds  new `enable_ipv6` Nginx attribute 
which allows an end-user to enable this IPv6 support in OPC's various 
Nginx config files.

/cc @stevendanna @sean-horn 
