### PR TITLE
Fix ARGV conditionals; Validate password length

### DIFF
--- a/files/private-chef-ctl-commands/password.rb
+++ b/files/private-chef-ctl-commands/password.rb
@@ -37,7 +37,7 @@ add_command "password", "Set a user's password or System Recovery Password.", 2 
     end
     
     if password.length < 6
-      puts "Minimum password length is six characters."
+      STDERR.puts "Minimum password length is six characters."
       exit 1
     end 
 


### PR DESCRIPTION
`private-chef-ctl password`  is not working at all in 1.4.6 versions of OPC . It references argument positions from the old, monolithic p-c-c, but we are now using the omnibus-ctl gem.
