### PR TITLE
[OC-8463] set sane sqerl idle_check value for oc_erchef

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -104,6 +104,7 @@
            {db_user, "<%= node['private_chef'][node['private_chef']['database_type']]['sql_user'] %>"},
            {db_pass, "<%= node['private_chef'][node['private_chef']['database_type']]['sql_password'] %>"},
            {db_name, "opscode_chef" },
+           {idle_check, 10000},
 
            {prepared_statements, {oc_chef_sql, statements, [<%= node['private_chef']['database_type'] == "postgresql" ? "pgsql" : "mysql" %>]}},
            {column_transforms,


### PR DESCRIPTION
This stops idle CPU usage by `oc_erchef`, which was considerably higher 
than in previous releases when using many PostgreSQL connections. This 
CPU usage appears to be harmless as it is caused by the idle_check'ing 
of PostgreSQL connections done by sqerl. `oc_bifrost` does not experience 
the same issue at the same level of db connections because in OPC 
idle_check is configured to 10000 (10 seconds). If no idle_check 
configurable is set then the sqerl default of 1000 (1 second) is used.

/cc @stevendanna @christophermaier @jkeiser 
