### PR TITLE
OC-3642: prevent split-brain keepalived

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -252,14 +252,13 @@ module PrivateChef
       PrivateChef['servers'].each do |k, v|
         next unless v['role'] == "backend"
         next if k == node_name
-        PrivateChef['servers'][node_name]['peer_ipaddress'] = v['cluster_ipaddress'] || v['ipaddress']
+        PrivateChef['servers'][node_name]['peer_ipaddress'] = v['ipaddress']
       end
       PrivateChef["keepalived"]["enable"] ||= true
-      PrivateChef["keepalived"]["vrrp_instance_interface"] = backend_vip["heartbeat_device"]
+      PrivateChef["keepalived"]["vrrp_instance_interface"] = backend_vip["device"]
       PrivateChef["keepalived"]["vrrp_instance_ipaddress"] = backend_vip["ipaddress"]
       PrivateChef["keepalived"]["vrrp_instance_ipaddress_dev"] = backend_vip["device"]
-      PrivateChef["keepalived"]["vrrp_instance_vrrp_unicast_bind"] =
-        PrivateChef['servers'][node_name]['cluster_ipaddress'] || PrivateChef['servers'][node_name]['ipaddress']
+      PrivateChef["keepalived"]["vrrp_instance_vrrp_unicast_bind"] = PrivateChef['servers'][node_name]['ipaddress']
       PrivateChef["keepalived"]["vrrp_instance_vrrp_unicast_peer"] = PrivateChef['servers'][node_name]['peer_ipaddress']
       PrivateChef["keepalived"]["vrrp_instance_ipaddress_dev"] = backend_vip["device"]
       PrivateChef["bookshelf"]["ha"] ||= true


### PR DESCRIPTION
- VVRP traffic needs to go over the VIP network
- this prevents both servers failing when the crossover link is broken
- this also prevents split brain
- the cluster_ipaddress is no used for drbd only
- the heartbeat_device is now no longer used and vestigial
- this is backwards compatible with existing config syntax, but all
  users will have their clusters 'fixed' as they upgrade
