### PR TITLE
[OC-9213] Major Bug In The opc_log_cleanup Shell Script

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -83,6 +83,7 @@ default['private_chef']['rabbitmq']['consumer_id'] = 'hotsauce'
 # Should always be enable = false, we control Jetty+Solr through opscode-solr
 default['private_chef']['jetty']['enable'] = false
 default['private_chef']['jetty']['ha'] = false
+default['private_chef']['jetty']['log_directory'] = "/var/opt/opscode/opscode-solr/jetty/logs"
 
 ####
 # Chef Solr


### PR DESCRIPTION
Any customer running OPC 1.4.6 will need this patch.

Simply makes a log_directory be available for jetty when we go through the loop at https://github.com/opscode/opscode-omnibus/blob/1.4.6/files/private-chef-cookbooks/private-chef/recipes/log_cleanup.rb#L12
