### PR TITLE
Overload from_file to catch error and raise on relevant file info

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -57,6 +57,11 @@ module PrivateChef
   class << self
 
     def from_file(filename)
+      # We're overriding this here so that we can get more meaningful errors from
+      # the reconfigure chef run; we don't particularly care what line in the chef
+      # recipes is failing to evaluate the loaded file (in the case of what
+      # originally triggered this, private_chef.rb), what we care about is which
+      # line in the loaded file is causing the error.
       begin
         self.instance_eval(IO.read(filename), filename, 1)
       rescue


### PR DESCRIPTION
The problem: right now, if (say) there's an error in the private_chef.rb (say, nagios is no longer part of private chef, and there are nagios settings), it raises with a fairly meaningless error (and hides the relevant information deep in the stack trace).  Yes, there's a problem with compiling the cookbook, but it isn't immediately clear why.

What this does is overload the function, catch the error, and re-raise with the filename and line number, so it's a little more obvious what happened and where the real problem is.
