### PR TITLE
Automated script for generating tech-preview wiki page

### DIFF
--- a/package_links/Gemfile
+++ b/package_links/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'aws-sdk'
+gem 'erubis'

--- a/package_links/Gemfile.lock
+++ b/package_links/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-sdk (1.8.5)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
+    erubis (2.7.0)
+    json (1.8.0)
+    nokogiri (1.5.9)
+    uuidtools (2.1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk
+  erubis

--- a/package_links/README.md
+++ b/package_links/README.md
@@ -1,0 +1,40 @@
+Automatically Generate Tech Preview Product Links
+=================================================
+
+# For the Impatient...
+
+``` sh
+export AWS_ACCESS_KEY_ID='...'
+export AWS_SECRET_ACCESS_KEY='...'
+bundle install
+bundle exec ./generate_wiki_page.rb | pbcopy
+# paste into wiki
+```
+
+# Background
+
+We store "tech preview" builds in a private S3 bucket for our main
+products (Private Chef, Reporting, Pushy, Web UI, and associated
+`knife` plugins).  These links are used by the sales department and
+others in the course of talking with and presenting demos to
+prospective clients.  These links need to expire, though, and
+maintaining the
+[wiki page](http://wiki.corp.opscode.com/display/CORP/Private+Chef+11+Preview+Builds)
+manually is a special kind of hell.
+
+This script automates the process: supply it with our current AWS
+"preprod" credentials (see [Teampass](http://teampass.opscode.com))
+via environment variables and it will generate the full Confluence
+wiki markup for the above-linked page, complete with freshly-minted
+URLs that expire (by default) in 7 days.  When it's time to refresh
+the URLs, just run the script and paste the entire output into the
+wiki and hit "Save".
+
+Apart from AWS credentials, the other main inputs to the script are a
+list of packages to create links for, as well as an S3 bucket name
+("opc11-tech-preview") and a default "time to live" value for the
+links (currently 7 days).  As these are relatively stable, they're
+built into the script.  As new preview builds are generated, the
+package list should be updated as needed.  You only need a list of
+package names (no deeply-nested hashes in JSON, as with Omnitruck);
+the product and platform information are extracted from the name.

--- a/package_links/confluence_page.erb
+++ b/package_links/confluence_page.erb
@@ -1,0 +1,47 @@
+{warning}
+These builds are intended for demo and evaluation purposes only!
+Under no circumstances should a customer or sales prospect use them in a production or other business critical environment.
+{warning}
+
+{info}
+<% expiration_date =  Time.now + (60 * 60 * 24 * days_valid) %>
+All links expire on <%= expiration_date.strftime("%B %-d, %Y") %>.
+To regenerate the contents of this page, use [this code|https://github.com/opscode/opscode-omnibus/tree/master/package_links]
+{info}
+
+h3. Private Chef Server
+<% info[:private_chef].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>
+
+h3. Run History (Reporting)
+<% info[:reporting].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>
+
+h3. Run History Knife Plugin (Reporting)
+<% info[:knife_reporting].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>
+
+h3. Push Jobs Server
+{note}The server requires at least 2 CPU cores. DO NOT attempt to run the server on a single core configuration as it will crash.{note}
+<% info[:push_jobs_server].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>
+
+h3. Push Jobs Client
+<% info[:push_jobs_client].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>
+
+h3. Push Job Knife Plugin
+<% info[:knife_push_jobs].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>
+
+h3. Web UI
+{note}After [configuration|https://github.com/opscode/omnibus-webui#configuration] it should run on port 2013 by default.{note}
+<% info[:webui].each do |kv| %>
+[<%= kv[0] %>|<%= kv[1] %>]
+<% end %>

--- a/package_links/generate_wiki_page.rb
+++ b/package_links/generate_wiki_page.rb
@@ -1,0 +1,185 @@
+#!/usr/bin/env ruby
+
+require 'aws'
+require 'erubis'
+
+module OCTechPreview
+
+  class WikiPage
+    def initialize(preview_info)
+      @preview_info = preview_info
+    end
+
+    def text
+      t = Erubis::Eruby.new(template)
+      data = {:info => @preview_info.as_hash, :days_valid => @preview_info.days_valid}
+      t.result(data)
+    end
+
+    def template
+      File.read("confluence_page.erb")
+    end
+  end
+
+  class URLGenerator
+    attr_reader :days_valid
+
+    def initialize(id, secret, bucket, days_valid=7)
+      @id, @secret, @bucket, @days_valid = id, secret, bucket, days_valid
+      @config = AWS.config(:access_key_id => @id, :secret_access_key => @secret, :region => 'us-west-2')
+      @s3 = AWS::S3.new
+    end
+
+    def url_for(package)
+      o = @s3.buckets[@bucket].objects[package]
+      o.url_for(:get, :expires => (60 * 60 * 24 * @days_valid))
+    end
+  end
+
+  class PreviewInfo
+    def initialize(packages, url_generator)
+      @packages = packages
+      @url_generator = url_generator
+    end
+
+    def days_valid
+      @url_generator.days_valid
+    end
+
+    def as_hash
+      @hash ||= begin
+                  @packages.inject({}) do |hash, package|
+                    info = PackageInfo.new(package)
+                    url = @url_generator.url_for(package)
+                    entry = {info.product => [[info.label, url]]}
+                    hash.merge!(entry) do |key, oldval, newval|
+                      oldval << newval.first
+                    end
+                    hash
+                  end
+                end
+    end
+  end
+
+  class PackageInfo
+    attr_reader :package
+
+    def initialize(package)
+      @package = package
+    end
+
+    def label
+      l = platform
+      l << " (#{architecture})" if architecture
+      l
+    end
+
+    def platform
+      case @package
+      when /\.el5\./
+        "CentOS 5"
+      when /\.el6\./
+        "Centos 6"
+      when /ubuntu\.10\.04/
+        "Ubuntu 10.04"
+      when /ubuntu\.11\.04/
+        "Ubuntu 11.04"
+      when /windows\.msi/
+        "Windows"
+      when /\.gem/
+        "All Platforms"
+      else
+        raise "Unrecognized package format for '#{@package}; could not determine platform!"
+      end
+    end
+
+    # @returns [String, nil] nil if no architecture is detected (this
+    # happens with e.g., Windows and Gem packages, and is not an
+    # error)
+    def architecture
+      case @package
+      when /x86_64/, /amd64/
+        "64-bit"
+      when /i686/, /i386/
+        "32-bit"
+      end
+    end
+
+    def product
+      case @package
+      when /private-chef/
+        :private_chef # "Private Chef Server"
+      when /opscode-reporting/
+        :reporting #"Run History (Reporting)"
+      when /knife-reporting/
+        :knife_reporting #"Run History Knife Plugin (Reporting)"
+      when /opscode-push-jobs-server/
+        :push_jobs_server #"Push Job Server"
+      when /opscode-push-jobs-client/
+        :push_jobs_client #"Push Job Client"
+      when /knife-pushy/
+        :knife_push_jobs #"Push Job Knife Plugin"
+      when /opscode-webui/
+        :webui #"Web UI"
+      else
+        raise "Unrecognized package format for '#{@package}; could not determine product!"
+      end
+    end
+
+  end
+end
+
+if __FILE__ == $0
+
+  BUCKET_NAME = "opc11-tech-preview"
+  DAYS_VALID  = 7
+
+  id     = ENV['AWS_ACCESS_KEY_ID']     || raise("No AWS_ACCESS_KEY_ID environment variable set!")
+  secret = ENV['AWS_SECRET_ACCESS_KEY'] || raise("No AWS_SECRET_ACCESS_KEY environment variable set!")
+
+  packages = [
+              # Private Chef
+              "private-chef-11.0.0_tech.preview.2+20130624205025-1.el5.x86_64.rpm",
+              "private-chef-11.0.0_tech.preview.2+20130624205025-1.el6.x86_64.rpm",
+              "private-chef_11.0.0-tech.preview.2+20130624205025-1.ubuntu.10.04_amd64.deb",
+              "private-chef_11.0.0-tech.preview.2+20130624205025-1.ubuntu.11.04_amd64.deb",
+
+              # Reporting
+              "opscode-reporting-0.2.0_tech.preview.2-1.el5.x86_64.rpm",
+              "opscode-reporting-0.2.0_tech.preview.2-1.el6.x86_64.rpm",
+              "opscode-reporting_0.2.0-tech.preview.2-1.ubuntu.10.04_amd64.deb",
+              "opscode-reporting_0.2.0-tech.preview.2-1.ubuntu.11.04_amd64.deb",
+
+              "knife-reporting-0.1.0.gem",
+
+              # Pushy
+              "opscode-push-jobs-server-0.9.0_tech.preview.1-1.el5.x86_64.rpm",
+              "opscode-push-jobs-server-0.9.0_tech.preview.1-1.el6.x86_64.rpm",
+              "opscode-push-jobs-server_0.9.0-tech.preview.1-1.ubuntu.10.04_amd64.deb",
+              "opscode-push-jobs-server_0.9.0-tech.preview.1-1.ubuntu.11.04_amd64.deb",
+
+              "opscode-push-jobs-client-0.0.1+20130307153525.git.98.c04f587-1.windows.msi",
+              "opscode-push-jobs-client-0.9.0_tech.preview.1+20130621231152.git.1.b4a8992-1.el5.i686.rpm",
+              "opscode-push-jobs-client-0.9.0_tech.preview.1+20130621231152.git.1.b4a8992-1.el5.x86_64.rpm",
+              "opscode-push-jobs-client-0.9.0_tech.preview.1+20130621231152.git.1.b4a8992-1.el6.i686.rpm",
+              "opscode-push-jobs-client-0.9.0_tech.preview.1+20130621231152.git.1.b4a8992-1.el6.x86_64.rpm",
+              "opscode-push-jobs-client_0.9.0-tech.preview.1+20130621231152.git.1.b4a8992-1.ubuntu.10.04_i386.deb",
+              "opscode-push-jobs-client_0.9.0-tech.preview.1+20130621231152.git.1.b4a8992-1.ubuntu.10.04_amd64.deb",
+              "opscode-push-jobs-client_0.9.0-tech.preview.1+20130621231152.git.1.b4a8992-1.ubuntu.11.04_i386.deb",
+              "opscode-push-jobs-client_0.9.0-tech.preview.1+20130621231152.git.1.b4a8992-1.ubuntu.11.04_amd64.deb",
+
+              "knife-pushy-0.1.gem",
+
+              # Web UI
+              "opscode-webui-0.1.0_tech.preview.3-1.el5.x86_64.rpm",
+              "opscode-webui-0.1.0_tech.preview.3-1.el6.x86_64.rpm",
+              "opscode-webui_0.1.0-tech.preview.3-1.ubuntu.10.04_amd64.deb",
+              "opscode-webui_0.1.0-tech.preview.3-1.ubuntu.11.04_amd64.deb"
+             ]
+
+  url_generator = OCTechPreview::URLGenerator.new(id, secret, BUCKET_NAME, DAYS_VALID)
+  preview_info  = OCTechPreview::PreviewInfo.new(packages, url_generator)
+  wiki_page     = OCTechPreview::WikiPage.new(preview_info)
+
+  puts wiki_page.text
+end


### PR DESCRIPTION
This automates the generation of timed-expiration S3 links to various
tech preview packages for all our products.  Given AWS credentials, it
will generate the complete Confluence wiki markup to replace the
entire contents of
http://wiki.corp.opscode.com/display/CORP/Private+Chef+11+Preview+Builds
with new links that are good for one week.

It is designed to be simple to maintain and use, since doing this
stuff by hand is a special kind of hell.

Although this deals with packages other than just Private Chef,
putting this code in this repository seemed better than creating a new
repository for it (too heavy-weight) or sticking it in a Gist (easy to
"lose").
