### PR TITLE
oc_erchef 0.21.17

### DIFF
--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-version "0.21.16"
+version "0.21.17"
 
 dependency "erlang"
 dependency "rebar"


### PR DESCRIPTION
Updates for erchef to pull in sqerl changes that set pooler to run as a top-level application and removes emysql as a dependency.

Ping @schisamo 

http://andra.ci.opscode.us/job/private-chef-test/425/
