### PR TITLE
Removed config for no-longer-supported custom acls

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -346,12 +346,6 @@ default['private_chef']['oc_bifrost']['sql_password'] = "challengeaccepted"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"
 default['private_chef']['oc_bifrost']['sql_ro_password'] = "foreveralone"
 
-default['private_chef']['oc_bifrost']['custom_acls_always_for_modification'] = true
-default['private_chef']['oc_bifrost']['custom_acls_cookbooks'] = true
-default['private_chef']['oc_bifrost']['custom_acls_data'] = true
-default['private_chef']['oc_bifrost']['custom_acls_depsolver'] = true
-default['private_chef']['oc_bifrost']['custom_acls_roles'] = true
-
 ####
 # Authz
 ####

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -28,12 +28,6 @@
               %% how many nodes are deserialized at a time in
               %% preparing a response.
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
-              {custom_acls_always_for_modification, <%= node['private_chef']['oc_bifrost']['custom_acls_always_for_modification'] %>},
-
-              {custom_acls_depsolver, <%= node['private_chef']['oc_bifrost']['custom_acls_depsolver'] %>},
-              {custom_acls_data, <%= node['private_chef']['oc_bifrost']['custom_acls_data'] %>},
-              {custom_acls_cookbooks, <%= node['private_chef']['oc_bifrost']['custom_acls_cookbooks'] %>},
-              {custom_acls_roles, <%= node['private_chef']['oc_bifrost']['custom_acls_roles'] %>},
 	      {superusers, [<<"pivotal">>]},
               %% metrics config
               {root_metric_key, "<%= @root_metric_key %>"},


### PR DESCRIPTION
Since we're removing server support for bypassing external authz acl checks (using default acls returned internally instead), we can remove the configuration settings (since they no longer do anything).  This was originally done for uncle Ned but is now no longer needed.
