### PR TITLE
Add a pre-install script

### DIFF
--- a/package-scripts/private-chef/preinst
+++ b/package-scripts/private-chef/preinst
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -e /usr/bin/private-chef-ctl ]; then
+   echo -e "\033[1mYou are about to upgrade Private Chef!\033[0m"
+   echo
+   echo "To ensure the process goes as smoothly as possible, we"
+   echo "will be shutting down all Private Chef-related services"
+   echo "on this machine before the new installer runs."
+   echo
+   /usr/bin/private-chef-ctl stop
+   echo
+fi


### PR DESCRIPTION
Will require updates in opscode/omnibus-ruby#69 to work, though.

Currently looks like this when doing an upgrade:

```
vagrant@private-chef:~$ sudo dpkg -i /vagrant/private-chef_11.0.0-tech.preview.3+20130816151730.git.37.59f8fa0-1.ubuntu.10.04_amd64.deb
(Reading database ... 117733 files and directories currently installed.)
Preparing to replace private-chef 1.4.6-1.ubuntu.10.04 (using .../private-chef_11.0.0-tech.preview.3+20130816151730.git.37.59f8fa0-1.ubuntu.10.04_amd64.deb) ...
You are about to upgrade Private Chef!

To ensure the process goes as smoothly as possible, we
will be shutting down all Private Chef-related services
on this machine before the new installer runs.

ok: down: couchdb: 0s, normally up
ok: down: fcgiwrap: 0s, normally up
ok: down: nagios: 1s, normally up
ok: down: nginx: 0s, normally up
ok: down: nrpe: 1s, normally up
ok: down: opscode-account: 0s, normally up
ok: down: opscode-authz: 1s, normally up
ok: down: opscode-certificate: 0s, normally up
ok: down: opscode-chef: 0s, normally up
ok: down: opscode-erchef: 1s, normally up
ok: down: opscode-expander: 0s, normally up
ok: down: opscode-expander-reindexer: 0s, normally up
ok: down: opscode-org-creator: 1s, normally up
ok: down: opscode-solr: 0s, normally up
ok: down: opscode-webui: 0s, normally up
ok: down: php-fpm: 0s, normally up
ok: down: postgresql: 1s, normally up
ok: down: rabbitmq: 0s, normally up
ok: down: redis: 1s, normally up
Unpacking replacement private-chef ...

etc...
```
