### PR TITLE
Temporarily add mysql2 definition

### DIFF
--- a/config/software/mysql2.rb
+++ b/config/software/mysql2.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Enable MySQL support by adding the following to '/etc/chef-server/chef-server.rb':
+#
+#   database_type = 'mysql'
+#   postgresql['enable'] = false
+#   mysql['enable'] = true
+#   mysql['destructive_migrate'] = true
+#
+# Then run 'chef-server-ctl reconfigure'
+#
+
+
+# NOTE #################################
+#
+# This definition should be removed once Enterprise Chef 11 is merged
+# to master.
+#
+########################################
+
+name "mysql2"
+versions_to_install = [ "0.3.6", "0.3.7" ]
+version versions_to_install.join("-")
+
+dependency "ruby"
+dependency "bundler"
+
+build do
+  gem "install rake-compiler --version 0.8.3"
+  command "mkdir -p #{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
+  versions_to_install.each do |ver|
+    gem "fetch mysql2 --version #{ver}", :cwd => "#{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
+  end
+end


### PR DESCRIPTION
The recent 9.0.0 release of the rake-compiler gem requires rubygems
1.8.25 or greater. This simply locks down what we were using before.

I would have added this to omnibus-software instead (and may still),
but that pulls in some different changes that appear to be
incompatible with the way we have opscode-authz set up, sadly enough.
Since opscode-authz is going away real soon anyway, this seems like
the lowest-impact way to get the master branch building cleanly again.

Once the new Enterprise Chef 11 work lands on master, we can revert
this commit.
