### PR TITLE
fix port 80 redirect

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -51,9 +51,8 @@ http {
       <%- else -%>
           server {
             listen <%= @helper.listen_port('http') %>;
-            server_name <%= @server_name %>;
             access_log /var/log/opscode/nginx/rewrite-port-80.log;
-            rewrite ^(.*) https://$server_name$1 permanent;
+            return 301 https://$host$request_uri;
           }
       <%- end -%>
     <%-  end %>


### PR DESCRIPTION
1. redirect to whatever host we were called with no matter what api_fqdn
   is set to via using $host.
2. avoid 'taxing' rewrites
   (http://wiki.nginx.org/Pitfalls#Taxing_Rewrites)
