### PR TITLE
Add Sqitch migration upgrade step

### DIFF
--- a/config/projects/private-chef.rb
+++ b/config/projects/private-chef.rb
@@ -29,7 +29,15 @@ dependency "postgresql92"
 dependency "rabbitmq"
 dependency "opscode-solr"
 dependency "opscode-expander"
-dependency "chef-sql-schema" # needed to migrate the DB.
+
+# We are transitioning away from Sequel toward Sqitch for managing
+# Erchef's schema.  We still need the old code ('chef-sql-schema') for
+# existing upgrades.  However, after Enterprise Chef 11's release,
+# that will be removed entirely in favor of the new code
+# ('enterprise-chef-server-schema').
+dependency "chef-sql-schema" # EOL
+dependency "enterprise-chef-server-schema"
+
 dependency "keepalived"
 dependency "bookshelf"
 

--- a/config/software/chef-server-schema.rb
+++ b/config/software/chef-server-schema.rb
@@ -1,0 +1,12 @@
+name "chef-server-schema"
+version "1.0.3"
+
+dependency "sqitch"
+
+# TODO: Use https when this is finally open-sourced
+source :git => "git@github.com:opscode/chef-server-schema.git"
+
+build do
+  command "mkdir -p #{install_dir}/embedded/service/#{name}"
+  command "#{install_dir}/embedded/bin/rsync -a --delete --exclude=.git/*** --exclude=.gitignore ./ #{install_dir}/embedded/service/#{name}/"
+end

--- a/config/software/enterprise-chef-server-schema.rb
+++ b/config/software/enterprise-chef-server-schema.rb
@@ -1,0 +1,18 @@
+name "enterprise-chef-server-schema"
+version "2.0.0"
+
+# Note that if you need changes that came in for the base schema (the
+# one shared with Open Source Chef Server), you'll need to explicitly
+# manage that dependency's version.  There isn't currently any support
+# for that baked into enterprise-chef-server-schema, since it's just
+# held together by Makefiles at the moment (i.e., there's no Bundler
+# or Rebar to nicely manage dependencies).
+
+dependency "chef-server-schema"
+
+source :git => "git@github.com:opscode/enterprise-chef-server-schema.git"
+
+build do
+  command "mkdir -p #{install_dir}/embedded/service/#{name}"
+  command "#{install_dir}/embedded/bin/rsync -a --delete --exclude=.git/*** --exclude=.gitignore ./ #{install_dir}/embedded/service/#{name}/"
+end

--- a/files/private-chef-upgrades/001/012_erchef_to_sqitch.rb
+++ b/files/private-chef-upgrades/001/012_erchef_to_sqitch.rb
@@ -1,0 +1,21 @@
+define_upgrade do
+
+  # This command ensures Sqitch has all the metadata for changes to
+  # the core schema up to version 1.0.1.  All these changes are
+  # already in the schema.
+  run_command("sqitch --db-user opscode-pgsql deploy --log-only --to-target @1.0.1",
+              :cwd => "/opt/opscode/embedded/service/chef-server-schema")
+
+  # There was a small change to the core schema that didn't make it
+  # into the previous incarnation of the Enterprise schema; this is a
+  # "real" deploy to pick up those changes.  This also removes the
+  # Sequel version metadata table.
+  run_command("sqitch --db-user opscode-pgsql deploy",
+              :cwd => "/opt/opscode/embedded/service/chef-server-schema")
+
+  # Finally, this loads up the change metadata for the Enterprise
+  # schema.  There are no changes to it that are not already in the
+  # existing schema, so it is '--log-only'.
+  run_command("sqitch --db-user opscode-pgsql deploy --log-only",
+              :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema")
+end


### PR DESCRIPTION
This will ensure that an EC11 system will have all Erchef schema
metadata in place for subsequent management by Sqitch.

Future releases and upgrades will then use Sqitch to actively handle
schema migrations.

cc: @jkeiser @seth
