### PR TITLE
modified platform_family logic

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/runit.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/runit.rb
@@ -14,11 +14,19 @@ case node["platform_family"]
 when "debian"
   include_recipe "private-chef::runit_upstart"
 when "rhel"
-  if node['platform_version'] =~ /^6/
+  case node['platform']
+  when "amazon"
+    # TODO: platform_version check for old distro version without upstart
     include_recipe "private-chef::runit_upstart"
   else
-    include_recipe "private-chef::runit_sysvinit"
+    if node['platform_version'] =~ /^5/
+      include_recipe "private-chef::runit_sysvinit"
+    else
+      include_recipe "private-chef::runit_upstart"
+    end
   end
+when "fedora"
+  include_recipe "private-chef::runit_upstart"
 else
   include_recipe "private-chef::runit_sysvinit"
 end


### PR DESCRIPTION
- amazon has platform_versions like "2013.03" which would have fallen
  through into the RHEL5-like case statement and been broken.  there is
  probably a rhel-5-like-vs-rhel-6-like breakpoint somewhere in the
  platform_versions here, but i don't know we really care that badly
  about old amazon platforms.
- i switched the case statement around to match rhel-5 tighter and
  fall through into rhel-6-like behavior, on the assumption that it is
  a lot more likely that rhel-7 will behave like rhel-6 and rhel-5 is
  certain to be wrong.
- fedora is not in the "rhel" family so added that explicitly and
  again made it rhel-6-like and older rhel5-like fedora is not supported
