### PR TITLE
Fix handling of user customized opscode_solr['heap_size'] config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   backend.
 * Introduce pluggable HA architecture as an alternative to DRBD
 * [OC-11673] Tune PostgreSQL keepalive timeouts
+* [OC-10117] opscode-solr4 accepts Java-like memory attributes
 
 ### openssl 1.0.1h
 * Allow ['lb']['upstream'] to have a custom setting

--- a/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -53,6 +53,39 @@ class OmnibusHelper
     File.exists?(bootstrap_sentinel_file)
   end
 
+  # Parse a config string as a memory value returning an integer in MB
+  # units.  Supported inputs (not case sensitive) are B, K/Kb, M/Mb,
+  # G/Gb. Uses integer division so values in B and Kb must exceed 1Mb.
+  def self.parse_mem_to_mb(mem_str)
+    if mem_str.is_a?(Integer)
+      return mem_str
+    end
+    regex = /(\d+)([GgmMkKbB]{0,2})/
+    m  = regex.match(mem_str)
+    raise "bad arg" if !m
+    raw_value = m[1].to_i
+    units = m[2]
+    value = case units
+            when /^b$/i
+              raw_value / (1024 * 1024)
+            when /^kb?$/i
+              raw_value / 1024
+            when /^mb?$/i
+              raw_value
+            when ""                       # no units, assume Mb
+              raw_value
+            when /^gb?$/i
+              raw_value * 1024
+            else
+              raise "unsupported memory units: #{mem_str}"
+            end
+    if value > 0
+      value
+    else
+      raise "zero Mb value not allowed: #{mem_str}"
+    end
+  end
+
   # generate a certificate signed by the opscode ca key
   #
   # === Returns

--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -90,7 +90,7 @@ node.default['private_chef']['opscode-solr4']['command'] =  "java -Xmx#{node['pr
 # Compute some sane JVM tunings. The user can still override these computed
 # defaults using /etc/opscode/private-chef.rb
 solr_mem = if node['private_chef']['opscode-solr4']['heap_size']
-              node['private_chef']['opscode-solr4']['heap_size']
+             OmnibusHelper.parse_mem_to_mb(node['private_chef']['opscode-solr4']['heap_size'])
            else
              node[:memory][:total] =~ /^(\d+)kB/
              memory_total_in_mb = $1.to_i / 1024
@@ -100,7 +100,7 @@ solr_mem = if node['private_chef']['opscode-solr4']['heap_size']
              [(memory_total_in_mb / 4), 1024].min
            end
 new_size =  if node['private_chef']['opscode-solr4']['new_size']
-              node['private_chef']['opscode-solr4']['new_size']
+              OmnibusHelper.parse_mem_to_mb(node['private_chef']['opscode-solr4']['new_size'])
             else
               [(solr_mem / 16), 32].max
             end


### PR DESCRIPTION
We were blindly using the value if provided assuming it was an
integer. This crashed if users customized with a value like '1G'.

This patch adds OmnibusHelper.parse_mem_to_mb which can handle common
memory suffixes as well as raw integer values (where Mb is assumed).

COMPLETELY UNTESTED!!!!!!!!

https://tickets.corp.opscode.com/browse/OC-10117
