### PR TITLE
Enable Groups in oc_erchef (0.21.34)

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-version "1.0.21"
+version "1.0.22"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-version "0.21.33"
+version "0.21.34"
 
 dependency "erlang"
 dependency "rebar"

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -260,7 +260,7 @@ default['private_chef']['lb']['chef_max_version'] = 11
 ###
 default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = true
+default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
 
 
 ####

--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -147,7 +147,7 @@ ruby_client_endpoint?      false
 ruby_users_endpoint?       <%= !node['private_chef']['dark_launch']['erlang_user_endpoint'] %>
 ruby_container_endpoint?  false
 ruby_container_endpoint_in_sql?  false
-ruby_group_endpoint?      true
+ruby_group_endpoint?      false
 
 old_runlists_and_search true
 


### PR DESCRIPTION
Integrates groups implemented in oc_erchef.

Update oc-chef-pedant to 1.0.22, updates for return codes and backwards compatibility for ruby endpoints.
Update oc_erchef to 0.21.34, adds the group chef object and support for bifrost interactions
Change the couch xdl header to false, choosing sql for group database operations
Change the oc-chef-pedant group ruby configuration to false using the updated return codes
