### PR TITLE
Remove recursive chown, run migration as opscode user.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
@@ -21,17 +21,8 @@ end
 
 execute "cookbook migration" do
   command cookbook_migration
+  user owner
   only_if { File.exist?(checksum_path) && !File.exist?(data_path) }
-end
-
-execute "reset bookshelf data owner" do
-  command "chown -R #{owner} #{data_path}"
-  only_if { File.exist?(data_path) }
-end
-
-execute "reset bookshelf data group" do
-  command "chgrp -R #{group} #{data_path}"
-  only_if { File.exist?(data_path) }
 end
 
 bookshelf_dir = node['private_chef']['bookshelf']['dir']


### PR DESCRIPTION
The recursive chown of the bookshelf files was only needed because the
migration created the files as the wrong user.  Running the migration
script as the correct user should ensure that the files get created
with the correct permission initially.
