### PR TITLE
OC-10478

### DIFF
--- a/files/private-chef-upgrades/001/010_chef_mover.rb
+++ b/files/private-chef-upgrades/001/010_chef_mover.rb
@@ -47,6 +47,7 @@ define_upgrade do
 
     # Restart chef-mover for the duration of the migration
     run_command("private-chef-ctl restart opscode-chef-mover")
+    sleep(60)
 
     # Perform the actual migration
     run_command("/opt/opscode/embedded/bin/escript /opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate")


### PR DESCRIPTION
Migration script would sometimes start before all mover services were fully running.
Made it a little cleaner at handling upgrade restarts and gave it a delay between starting mover and running the migrate script.
