### PR TITLE
[OC-10648] Fix check for disabled services in 008-fix-logging migration

### DIFF
--- a/files/private-chef-upgrades/001/008_fix_logging.rb
+++ b/files/private-chef-upgrades/001/008_fix_logging.rb
@@ -37,8 +37,8 @@ define_upgrade do
       run_command("chown opscode:opscode /var/log/opscode/#{service}/*")
 
       # There could be leftover logs for a service we don't use anymore...
-      # (e.g. authz). So check the service is defined before restartint it.
-      if File.exist?("/opt/opscode/sv/#{service}")
+      # (e.g. authz). So check the service is defined before restarting it.
+      if File.exist?("/opt/opscode/service/#{service}")
         # force svlogd process to reload
         run_command("/opt/opscode/embedded/bin/sv force-restart /opt/opscode/sv/#{service}/log")
       end


### PR DESCRIPTION
The component_runit_service resources enables and disables services by
creating or deleting links in the /opt/opscode/service directory.  The
migration script erroneously checks /opt/opscode/sv instead.

The errant check causes an error when upgrading from 1.4.6 to 11.0.1
because of commit 9de057f50ce33acaf7fef142b4239a5bb3595ceb which
disables opscode-certificate on frontend machines.
