### PR TITLE
Fix bookshelf directory creation problems in HA configurations (OC-10652)

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
@@ -19,36 +19,33 @@ template cookbook_migration do
   mode "0755"
 end
 
-directory data_path do
-  action :create
-  recursive true
-  owner owner
-  group owner
+#
+# We need to create all of these directories up front 
+# Note that data_path will not be a subdir of bookshelf_dir in HA configurations
+#
+bookshelf_dir = node['private_chef']['bookshelf']['dir']
+bookshelf_etc_dir = File.join(bookshelf_dir, "etc")
+bookshelf_log_dir = node['private_chef']['bookshelf']['log_directory']
+bookshelf_sasl_log_dir = File.join(bookshelf_log_dir, "sasl")
+[
+  bookshelf_dir,
+  bookshelf_etc_dir,
+  bookshelf_log_dir,
+  bookshelf_sasl_log_dir,
+  data_path
+].each do |dir_name|
+  directory dir_name do
+    owner owner
+    group owner
+    mode '0700'
+    recursive true
+  end
 end
 
 execute "cookbook migration" do
   command cookbook_migration
   user owner
   not_if { File.exist?("#{data_path}/_%_BOOKSHELF_DISK_FORMAT") }
-end
-
-bookshelf_dir = node['private_chef']['bookshelf']['dir']
-bookshelf_etc_dir = File.join(bookshelf_dir, "etc")
-bookshelf_log_dir = node['private_chef']['bookshelf']['log_directory']
-bookshelf_sasl_log_dir = File.join(bookshelf_log_dir, "sasl")
-bookshelf_data_dir = node['private_chef']['bookshelf']['data_dir']
-[
-  bookshelf_dir,
-  bookshelf_etc_dir,
-  bookshelf_log_dir,
-  bookshelf_sasl_log_dir,
-  bookshelf_data_dir,
-].each do |dir_name|
-  directory dir_name do
-    owner node['private_chef']['user']['username']
-    mode '0700'
-    recursive true
-  end
 end
 
 link "/opt/opscode/embedded/service/bookshelf/log" do


### PR DESCRIPTION
This is related to OC-10652, in that it looks like we didn't quite get all the corner cases when we revised
the setup in files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb 

We previously created the data_path directory, ran cookbook_migration, and then created the rest of
the directories. This hit a snag because in a non-HA config we would create the data_path directory
as something like "/var/opt/opscode/bookshelf/data" and as a byproduct create the
"/var/opt/opscode/bookshelf" directory. The cookbook_migration script would see this dir, and be happy.

In HA configs the data_path directory was instead "/var/opt/opscode/drbd/data/bookshelf", which
meant that we never created "/var/opt/opscode/bookshelf", and the cookbook_migration script would
break.

We probably will need to make sure that this change doesn't impact the cookbook_migration process; I
believe that it will be fine, but I've not tested it on a system with data.

This also points up the dire need to automate our HA setup process; it is highly manual, and so CI
can't test it.

@marcparadise @seth @hosh @sdelano 
