### PR TITLE
Add missed fix from 1086f5badf

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -297,7 +297,7 @@ module PrivateChef
       PrivateChef["bookshelf"]["listen"] ||= PrivateChef["default_listen_address"]
       PrivateChef["couchdb"]["bind_address"] ||= PrivateChef["default_listen_address"]
       PrivateChef["rabbitmq"]["node_ip_address"] ||= PrivateChef["default_listen_address"]
-      PrivateChef["nginx"]["enable_ipv6"] = PrivateChef["use_ipv6"]
+      PrivateChef["nginx"]["enable_ipv6"] ||= PrivateChef["use_ipv6"]
       PrivateChef["opscode_solr"]["ip_address"] ||= PrivateChef["default_listen_address"]
       PrivateChef["opscode_webui"]["worker_processes"] ||= 2
       PrivateChef["postgresql"]["listen_address"] ||= '*' #PrivateChef["default_listen_address"]


### PR DESCRIPTION
Do not disable nginx ipv6 if it has been explicitly enabled

We fixed the front ends, but didn't fix the backend.

@mp @sf
