### PR TITLE
 [OC-10741] Use new omnibus-software to update keepalived to 1.2.9 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: ccbd058b127483e5c3e1471eee40c7f66e23a244
+  revision: 8dddc1b8f63e2c4438974837777207f7b755f152
   branch: master
   specs:
     omnibus-software (0.0.1)

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-keepalived-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-keepalived-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -P /opt/opscode/embedded/sbin/keepalived --log-console --log-detail --dont-fork --use-file <%= File.join(node["private_chef"]["keepalived"]["dir"], "etc", "keepalived.conf") %>
+exec chpst -P /opt/opscode/embedded/sbin/keepalived --log-console --log-detail --dont-fork --use-file=<%= File.join(node["private_chef"]["keepalived"]["dir"], "etc", "keepalived.conf") %>


### PR DESCRIPTION
Use new omnibus-software to update keepalived to 1.2.9 + patch for centos 5.5 [OC-10741]

CI passes for all OSs

@oferrigni  @seth @hosh @sdelano 
