### PR TITLE
Add lager to replace fast log in oc_erchef

### DIFF
--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-version "0.21.36"
+version "0.21.37"
 
 dependency "erlang"
 dependency "rebar"

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -10,12 +10,49 @@
          {error_logger_mf_maxbytes, <%= @log_rotation['file_maxbytes'] %>},
          {error_logger_mf_maxfiles, <%= @log_rotation['num_to_keep'] %>}
         ]},
- {fast_log, [
-             {loggers, [[{name, erchef},
-                         {file, "<%= File.join(@log_directory, 'erchef.log') %>"},
-                         {files, <%= @log_rotation['num_to_keep'] %>},
-                         {file_size, <%= (@log_rotation['file_maxbytes'].to_f/1024/1024).round %>}]]}
-            ]},
+ {lager, [
+          {handlers, [
+              {lager_console_backend, [info, {lager_default_formatter, ["[", severity, "] ", message, "\n"]}]},
+              {lager_file_backend, [
+                                    {file, "<%= File.join(@log_directory, 'erchef.log') %>"},
+                                    {level, info},
+                                    {size, <%= @log_rotation['file_maxbytes'] %>},
+                                    {date, "$D0"},
+                                    {count, <%= @log_rotation['num_to_keep'] %>},
+                                    {formatter_config, [date, " ", time, " [", severity, "] ", message, "\n"]}
+                                   ]}
+              ]},
+
+          %% Whether to write a crash log, and where.
+          %% Commented/omitted/undefined means no crash logger.
+          {crash_log, "<%= File.join(@log_directory, 'crash.log') %>"},
+
+          %% Maximum size in bytes of events in the crash log - defaults to 65536
+          {crash_log_msg_size, 65536},
+
+          %% Maximum size of the crash log in bytes, before its rotated, set
+          %% to 0 to disable rotation - default is 0
+          {crash_log_size, <%= @log_rotation['file_maxbytes'] %>},
+
+          %% What time to rotate the crash log - default is no time
+          %% rotation. See the lager README for a description of this format:
+          %% https://github.com/basho/lager/blob/master/README.org
+          {crash_log_date, "$D0"},
+
+          %% Number of rotated crash logs to keep, 0 means keep only the
+          %% current one - default is 0
+          {crash_log_count, <%= @log_rotation['num_to_keep'] %>},
+
+          %% Whether to redirect error_logger messages into lager - defaults to true
+          {error_logger_redirect, true},
+
+          %% Bump up the "high-water mark" (default 50), which is the
+          %% number of messages per second allowed to come from
+          %% error_logger.  This is the same as used by
+          %% opscode-chef-mover, FWIW.
+          {error_logger_hwm, 1000}
+        ]},
+
  {oc_chef_wm, [
               {api_version, "<%= node['private_chef']['api_version'] %>"},
               {server_flavor, "<%= node['private_chef']['flavor'] %>"},


### PR DESCRIPTION
Provides persistent tracing in oc_erchef which will be used in solr -> sol4
transition.
