### PR TITLE
Possible fix for problem Facebook encountered when load testing IPv6 release.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -324,9 +324,9 @@ module PrivateChef
       PrivateChef["rabbitmq"]["enable"] ||= false
       PrivateChef["rabbitmq"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
 
-      PrivateChef["opscode_certificate"]["enable"] ||= false
-      # Why is this even needed?
-      PrivateChef["opscode_certificate"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
+      # move certgen back to front ends; the backend canna handle the load
+      PrivateChef["opscode_certificate"]["enable"] ||= true
+      PrivateChef["opscode_certificate"]["vip"] ||= '127.0.0.1'
 
       PrivateChef["opscode_solr"]["enable"] ||= false
       PrivateChef["opscode_solr"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]


### PR DESCRIPTION
Possible fix for problem Facebook encountered when load testing IPv6 release.

This reverts a change in 11.0.1 to use the certificate generation on the backend instead of the front end boxes. The opscode-certgen service on the back end was unable to keep up with the request rate, and started generating 499/500's via nginx.

@seth @stevendanna 
