### PR TITLE
mp/merge cert fe move

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -213,7 +213,6 @@ default['private_chef']['lb']['upstream']['opscode-webui'] = [ "127.0.0.1" ]
 default['private_chef']['lb']['upstream']['oc_bifrost'] = [ "127.0.0.1" ]
 default['private_chef']['lb']['upstream']['opscode-solr'] = [ "127.0.0.1" ]
 default['private_chef']['lb']['upstream']['bookshelf'] = [ "127.0.0.1" ]
-default['private_chef']['lb']['upstream']['opscode-certificate'] = [ "127.0.0.1" ]
 default['private_chef']['lb_internal']['enable'] = true
 default['private_chef']['lb_internal']['vip'] = "127.0.0.1"
 default['private_chef']['lb_internal']['chef_port'] = 9680

--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -303,8 +303,7 @@ module PrivateChef
       PrivateChef["opscode_solr"]["ip_address"] ||= PrivateChef["default_listen_address"]
       PrivateChef["opscode_webui"]["worker_processes"] ||= 2
       PrivateChef["postgresql"]["listen_address"] ||= '*' #PrivateChef["default_listen_address"]
-
-      PrivateChef["opscode_certificate"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
+      PrivateChef["opscode_certificate"]["vip"] ||= '127.0.0.1'
 
       authaddr = []
       authaddr << "0.0.0.0/0" # if PrivateChef["use_ipv4"]

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx.conf.erb
@@ -160,35 +160,7 @@ http {
       proxy_pass http://oc_bifrost;
     }
   }
-  # internal service access for opscode-certificate, temporary until we modify the code to
-  # allow us to specify listening address more easily.
-  # This is ipv6-specific and is not required for ipv4.
-  <% if node['private_chef']['nginx']['enable_ipv6'] %>
-  server {
-  <%= @helper.listen_port(node['private_chef']['opscode-certificate']['port'], :ipv6_only  => true ) %>
-    server_name <%= node['fqdn'] %>;
-
-    client_max_body_size <%= @client_max_body_size %>;
-    # We cannot tell the upstream where we reall came from because
-    # he'll go all to pieces if he sees an ipv6 address.
-    # As a result, we'll explicitly set a Host header value
-    # and will not pass along any headers that webmachine may use to identify the real host.
-    proxy_set_header        Host            "127.0.0.1";
-    proxy_set_header        X-Forwarded-Proto http;
-
-    proxy_connect_timeout   90;
-    proxy_send_timeout      90;
-    proxy_read_timeout      90;
-
-    access_log /var/log/opscode/nginx/internal-certificate.access.log opscode;
-    error_log  /var/log/opscode/nginx/internal-certificaet.error.log<%= node['private_chef']['lb']['debug'] ? " debug" : "" %>;
-
-    location / {
-      proxy_pass http://opscode_certificate;
-    }
-  }
-  <%- end -%> # provide cert int if ipv6 only
-  <%- end -%> # if enable lb int
+  <%- end  # if enable lb int -%>
 
   include <%= node['private_chef']['nginx']['dir'] %>/etc/nginx.d/*.conf;
 }


### PR DESCRIPTION
Pull in @manderson26 's enabling of cert server on FE.  Change BE to explicitly require BE services to contact  cert serveron  ipv4 localhost as well, and remove nginx ipv6 proxy for certificate server since cert server will no longer service requests inbound from external interfaces. 

ping @manderson26  @sf /cc @hosh  @sdelano @oferrigni 
