### PR TITLE
Add redis back into the opscode-omnibus build.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 8dddc1b8f63e2c4438974837777207f7b755f152
+  revision: 448648b6ac34cbcfdc8ebdd913e103922744eb27
   branch: master
   specs:
     omnibus-software (0.0.1)

--- a/config/projects/private-chef.rb
+++ b/config/projects/private-chef.rb
@@ -20,6 +20,7 @@ dependency "private-chef-scripts" # assorted scripts used by installed instance
 dependency "private-chef-ctl" # additional project-specific private-chef-ctl subcommands
 dependency "private-chef-administration"
 dependency "openresty"
+dependency "redis-rb" # gem for interacting with redis
 dependency "runit"
 dependency "unicorn"
 
@@ -27,6 +28,7 @@ dependency "unicorn"
 dependency "couchdb"
 dependency "postgresql92"
 dependency "rabbitmq"
+dependency "redis" # dynamic routing controls
 dependency "opscode-solr"
 dependency "opscode-expander"
 

--- a/config/software/redis-rb.rb
+++ b/config/software/redis-rb.rb
@@ -1,0 +1,25 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name "redis-rb"
+version "3.0.4"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  gem "install redis -n #{install_dir}/bin --no-rdoc --no-ri -v #{version}"
+end

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -1,4 +1,4 @@
-#
+
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Copyright:: Copyright (c) 2012 Opscode, Inc.
 #
@@ -199,6 +199,37 @@ default['private_chef']['oc-chef-pedant']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['oc-chef-pedant']['debug_org_creation'] = false
 
 ###
+# Redis
+###
+default['private_chef']['redis']['enable'] = true
+default['private_chef']['redis']['ha'] = false
+default['private_chef']['redis']['dir'] = "/var/opt/opscode/redis-lb"
+default['private_chef']['redis']['data_dir'] = "/var/opt/opscode/redis-lb/data"
+default['private_chef']['redis']['log_directory'] = "/var/log/opscode/redis-lb"
+default['private_chef']['redis']['log_rotation']['file_maxbytes'] = 1000000
+default['private_chef']['redis']['log_rotation']['num_to_keep'] = 10
+default['private_chef']['redis']['port'] = "16379"
+default['private_chef']['redis']['bind'] = "127.0.0.1"
+default['private_chef']['redis']['vip'] = "127.0.0.1"
+default['private_chef']['redis']['keepalive'] = "60"
+default['private_chef']['redis']['timeout'] = "300"
+default['private_chef']['redis']['loglevel'] = "notice"
+default['private_chef']['redis']['databases'] = "16"
+default['private_chef']['redis']['appendonly'] = "no"
+default['private_chef']['redis']['appendfsync'] = "always"
+default['private_chef']['redis']['activerehashing'] = "no"
+default['private_chef']['redis']['aof_rewrite_percent'] = "50"
+default['private_chef']['redis']['aof_rewrite_min_size'] = "16mb"
+default['private_chef']['redis']['maxmemory'] = "8m"
+default['private_chef']['redis']['maxmemory_policy'] = "noeviction"
+
+default['private_chef']['redis']['save_frequency'] = {
+  "900" => "1",
+  "300" => "10",
+  "60" => "1000"
+}
+
+###
 # Load Balancer
 ###
 default['private_chef']['lb']['enable'] = true
@@ -234,6 +265,7 @@ default['private_chef']['nginx']['non_ssl_port'] = 80
 default['private_chef']['nginx']['x_forwarded_proto'] = 'https'
 default['private_chef']['nginx']['server_name'] = node['fqdn']
 default['private_chef']['nginx']['url'] = "https://#{node['fqdn']}"
+
 # HIGHEST SECURITY AT ALL COSTS: TLSv1 only to prevent BEAST, can also turn off RC4/MEDIUM/MD5 to really favor security over speed/comptability
 #default['private_chef']['nginx']['ssl_protocols'] = "-ALL +TLSv1"
 #default['private_chef']['nginx']['ssl_ciphers'] = "RC4-SHA:RC4-MD5:RC4:RSA:HIGH:MEDIUM:!LOW:!kEDH:!aNULL:!ADH:!eNULL:!EXP:!SSLv2:!SEED:!CAMELLIA:!PSK"
@@ -504,6 +536,7 @@ default['private_chef']['keepalived']['vrrp_instance_vrrp_unicast_bind'] = node[
 default['private_chef']['keepalived']['vrrp_instance_vrrp_unicast_peer'] = nil
 default['private_chef']['keepalived']['vrrp_instance_preempt_delay'] = 30
 default['private_chef']['keepalived']['vrrp_instance_nopreempt'] = true
+
 default['private_chef']['keepalived']['service_posthooks'] = {
     "rabbitmq" => "/opt/opscode/bin/wait-for-rabbit"
 }

--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -31,6 +31,7 @@ module PrivateChef
   lb Mash.new
   lb_internal Mash.new
   postgresql Mash.new
+  redis Mash.new
   oc_bifrost Mash.new
   opscode_certificate Mash.new
   opscode_org_creator Mash.new
@@ -185,6 +186,7 @@ module PrivateChef
       results = { "private_chef" => {} }
       [
         "opscode_chef",
+        "redis",
         "couchdb",
         "rabbitmq",
         "opscode_solr",
@@ -244,6 +246,7 @@ module PrivateChef
       PrivateChef['bookshelf']['data_dir'] = "/var/opt/opscode/drbd/data/bookshelf"
       PrivateChef["rabbitmq"]["data_dir"] ||= "/var/opt/opscode/drbd/data/rabbitmq"
       PrivateChef["opscode_solr"]["data_dir"] ||= "/var/opt/opscode/drbd/data/opscode-solr"
+      PrivateChef["redis"]["data_dir"] ||= "/var/opt/opscode/drbd/data/redis-lb"
 
       # The postgresql data directory is scoped to the current version;
       # changes in the directory trigger upgrades from an old PostgreSQL
@@ -287,6 +290,7 @@ module PrivateChef
       PrivateChef["opscode_webui"]["ha"] ||= true
       PrivateChef["lb"]["ha"] ||= true
       PrivateChef["postgresql"]["ha"] ||= true
+      PrivateChef["redis"]["ha"] ||= true
       PrivateChef["oc_bifrost"]["ha"] ||= true
       PrivateChef["opscode_certificate"]["ha"] ||= true
       PrivateChef["opscode_org_creator"]["ha"] ||= true
@@ -299,6 +303,7 @@ module PrivateChef
       PrivateChef["bookshelf"]["listen"] ||= PrivateChef["default_listen_address"]
       PrivateChef["couchdb"]["bind_address"] ||= PrivateChef["default_listen_address"]
       PrivateChef["rabbitmq"]["node_ip_address"] ||= PrivateChef["default_listen_address"]
+      PrivateChef["redis"]["listen"] ||= PrivateChef["default_listen_address"]
       PrivateChef["nginx"]["enable_ipv6"] ||= PrivateChef["use_ipv6"]
       PrivateChef["opscode_solr"]["ip_address"] ||= PrivateChef["default_listen_address"]
       PrivateChef["opscode_webui"]["worker_processes"] ||= 2
@@ -324,6 +329,8 @@ module PrivateChef
       PrivateChef["couchdb"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
       PrivateChef["rabbitmq"]["enable"] ||= false
       PrivateChef["rabbitmq"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
+      PrivateChef["redis"]["enable"] ||= false
+      PrivateChef["redis"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
 
       # move certgen back to front ends; the backend canna handle the load
       PrivateChef["opscode_certificate"]["enable"] ||= true

--- a/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -159,6 +159,7 @@ include_recipe "private-chef::sysctl-updates"
   "bootstrap",
   "opscode-webui",
   "opscode-chef-mover",
+  "redis",
   "nginx",
   "keepalived"
 ].each do |service|

--- a/files/private-chef-cookbooks/private-chef/recipes/redis.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/redis.rb
@@ -1,0 +1,120 @@
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+# Author:: Marc A. Paradise <marc@opscode.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+redis = node['private_chef']['redis']
+redis_dir = redis['dir']
+redis_etc_dir = File.join(redis_dir, "etc")
+redis_data_dir = redis['data_dir']
+redis_data_dir_symlink = File.join(redis_dir, "data")
+redis_log_dir = redis['log_directory']
+
+[
+  redis_dir,
+  redis_etc_dir,
+  redis_data_dir,
+  redis_log_dir,
+].each do |dir_name|
+  directory dir_name do
+    owner node['private_chef']['user']['username']
+    mode '0700'
+    recursive true
+  end
+end
+
+redis_config = File.join(redis_etc_dir, "redis.conf")
+
+link redis_data_dir_symlink do
+  to redis_data_dir
+  not_if { redis_data_dir_symlink == redis_data_dir }
+end
+
+
+redis_data = redis
+template redis_config do
+  source "redis.conf.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  variables(redis_data.to_hash)
+  notifies :restart, 'service[redis]' if is_data_master?
+end
+
+component_runit_service "redis"
+
+# log rotation
+template "/etc/opscode/logrotate.d/redis" do
+  source "logrotate.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  variables(redis.to_hash)
+end
+
+#
+# This should be guarded by a test that redis is running
+#
+ruby_block "set_lb_redis_values" do
+  block do
+    require "redis"
+    redis = Redis.new(:host => redis_data.vip, :port => redis_data.port)
+    xdl = node['private_chef']['lb']['xdl_defaults']
+    banned_ips = PrivateChef['banned_ips']
+    maint_mode_ips = PrivateChef['maint_mode_whitelist_ips']
+    # Ensure there is no stale data, but first institute
+    # a brief maint mode to avoid potential misrouting when
+    # we delete old keys.
+    redis.hset "dl_default", "503_mode", true
+    next while not redis.spop("banned_ips").nil?
+    next while not redis.spop("maint_data").nil?
+    keys = redis.hkeys "dl_default"
+
+    # Clear all dl_default keys except for the 503 mode we just set.
+    redis.pipelined do
+      keys.each do |key|
+        redis.hdel "dl_default", key unless key == "503_mode"
+      end
+    end
+
+    redis.pipelined do
+      # Now we're clear to repopulate from configuration.
+      if (!banned_ips.nil?)
+        banned_ips.each do |ip|
+          redis.sadd   "banned_ips", ip
+        end
+      end
+      if (!maint_mode_ips.nil?)
+        maint_mode_ips.each do |ip|
+          redis.sadd   "maint_data", ip
+        end
+      end
+      # Note that we'll preserve 503 mode until everything is
+      # populated.
+      if (!xdl.nil?)
+        xdl.each do |key, value|
+          redis.hset("dl_default", key, value) unless key == "503_mode"
+        end
+      end
+    end
+
+    if xdl && xdl.has_key?("503_mode")
+      redis.hset "dl_default", "503_mode", xdl["503_mode"]
+    else
+      redis.hdel "dl_default", "503_mode"
+    end
+  end
+  action :create
+end

--- a/files/private-chef-cookbooks/private-chef/recipes/redis_disable.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/redis_disable.rb
@@ -1,0 +1,20 @@
+#
+# Copyright 2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+runit_service "redis" do
+  action :disable
+end
+

--- a/files/private-chef-cookbooks/private-chef/templates/default/redis.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/redis.conf.erb
@@ -1,0 +1,35 @@
+daemonize no
+pidfile <%=@dir%>/lb-redis.pid
+
+port <%= @port %>
+bind <%= @bind %> <%= @listen == @bind ? "" : @listen %>
+
+tcp-keepalive <%= @keepalive %>
+timeout <%= @timeout %>
+loglevel <%= @loglevel %>
+logfile ""
+
+databases <%= @databases %>
+
+<% @save_frequency.each do |dur, freq| %>
+save <%=dur%> <%=freq%>
+<% end %>
+
+rdbcompression yes
+dbfilename dump.rdb
+dir <%= File.join(@dir, "data") %>
+
+<% if not @maxmemory.nil? %>
+maxmemory <%= @maxmemory %>
+maxmemory-policy <%= @maxmemory_policy %>
+maxmemory-samples 3
+<% end %>
+
+appendonly <%= @appendonly %>
+appendfsync <%= @appendfsync %>
+
+no-appendfsync-on-rewrite no
+activerehashing <%=@activerehashing%>
+
+auto-aof-rewrite-percentage <%=@aof_rewrite_percent%>
+auto-aof-rewrite-min-size <%=@aof_rewrite_min_size%>

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-redis-log-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-redis-log-run.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec chpst -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> \
+  svlogd -tt <%= @options[:log_directory] %>

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-redis-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-redis-run.erb
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+exec chpst -P -o 131071 -u <%= node["private_chef"]["user"]["username"] %> -U <%= node["private_chef"]["user"]["username"] %> -o 100000 env HOME="<%= node["private_chef"]["redis"]["dir"] %>" /opt/opscode/embedded/bin/redis-server <%= File.join(node["private_chef"]["redis"]["dir"], "etc", "redis.conf") %>
+


### PR DESCRIPTION
This adds redis back into the opscode-omnibus build.

This includes:
- Update the  version of opscode-software to bring in redis 2.8.2
- Include redis and redis-rb gem in build
- Installation of redis in for both single instances and HA setups
- Log rotation

One note for future; substantial time was spent debugging the fact
that redis was missing from the hash merge in private_chef.rb; easy to
miss and a PITA to figure out after the fact.

This does not include:
- IPv6 testing
- Upgrade testing.

@marcparadise @seth @hosh @sdelano @oferrigni 
