### PR TITLE
Fix redis to listen to all networks in HA mode.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/redis.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/redis.conf.erb
@@ -2,7 +2,9 @@ daemonize no
 pidfile <%=@dir%>/lb-redis.pid
 
 port <%= @port %>
+<% if (@listen != "0.0.0.0") && (@listen != "::") %>
 bind <%= @bind %> <%= @listen == @bind ? "" : @listen %>
+<% end %>
 
 tcp-keepalive <%= @keepalive %>
 timeout <%= @timeout %>


### PR DESCRIPTION
We use 0.0.0.0 as the default bind address in HA mode. Redis doesn't understand that properly, and instead wants the bind clause to be dropped entirely.

@seth  @hosh @marcparadise @oferrigni 
