### PR TITLE
lb: Ensure that we do not attempt to match a nil chef client version

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
@@ -169,6 +169,9 @@ local uri_resolvers = {
 
 -- caller should bypass this client version check if caller is internal lb
 function routes.is_client_version_valid(version, min, max)
+  if (version == nil) then
+    return false
+  end
   local res = match(Ct(p_chef_version), version)
   if (res == nil) then
     return false


### PR DESCRIPTION
In EHC, if chef client version is missing we do not route the request
to the lua script - instead we display a friendly message saying the
user probably doesn't belong here.

However because of the dual purpose webui/api hosting in EC, we don't
have that check - which means we need to add explicit handling for
missing client version.

ping @seth @manderson26 @sdelano @hosh @oferrigni 
