### PR TITLE
Chef 4939 upgrade openssl

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 9b2c2cc3d2fa39cb7fefad3d348c91f2c5eb57a1
+  revision: 74879d5e996b222bfd67bf2363eb30726fc3484b
   branch: master
   specs:
     omnibus-software (0.0.1)


### PR DESCRIPTION
CHEF-4939, CVE-2013-4353: Upgrade to openssl 1.0.1f.
Fixes null pointer exception caused by carefully crafted invalid TLS handshakes.

Passing build:  
http://andra.ci.opscode.us/job/private-chef-trigger-ad-hoc/581/downstreambuildview/

@schisamo 
