### PR TITLE
Bring in fixes for opscode-account user/<users>/_acl endpoint, and tests

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-version "1.0.23"
+version "1.0.24"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/opscode-account.rb
+++ b/config/software/opscode-account.rb
@@ -1,5 +1,5 @@
 name "opscode-account"
-version "rel-1.39.0"
+version "rel-1.41.0"
 
 dependency "ruby"
 dependency "bundler"


### PR DESCRIPTION
At some point in time we broke the user/<users>/_acl endpoint. This includes a fix to properly create the Ace object, and some work to handle invalid users/groups in the ACL.

This slipped through the cracks because this endpoint was not tested in pedant. Added tests to provide some basic coverage.

http://andra.ci.opscode.us/job/private-chef-trigger-ad-hoc/598/

@sdelano ok'd this verbally, but getting at least some signoff formally is worthwhile practice.
@seth @marcparadise @hosh 
