### PR TITLE
Ma/fix keepalived

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -533,6 +533,7 @@ end
 ##
 default['private_chef']['keepalived']['enable'] = false
 default['private_chef']['keepalived']['dir'] = "/var/opt/opscode/keepalived"
+default['private_chef']['keepalived']['ipv6_on'] = false
 default['private_chef']['keepalived']['log_directory'] = "/var/log/opscode/keepalived"
 default['private_chef']['keepalived']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['keepalived']['log_rotation']['num_to_keep'] = 10

--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -289,6 +289,7 @@ module PrivateChef
         PrivateChef['servers'][node_name]['peer_ipaddress'] = v['ipaddress']
       end
       PrivateChef["keepalived"]["enable"] ||= true
+      PrivateChef["keepalived"]["ipv6_on"] ||= PrivateChef["use_ipv6"]
       PrivateChef["keepalived"]["vrrp_instance_interface"] = backend_vip["device"]
       PrivateChef["keepalived"]["vrrp_instance_ipaddress"] = backend_vip["ipaddress_with_netmask"]
       PrivateChef["keepalived"]["vrrp_instance_ipaddress_dev"] = backend_vip["device"]

--- a/files/private-chef-cookbooks/private-chef/templates/default/keepalived.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/keepalived.conf.erb
@@ -24,12 +24,17 @@ vrrp_instance <%= @vrrp_sync_instance %> {
     interface <%= @vrrp_instance_interface %>
     virtual_router_id <%= @vrrp_instance_virtual_router_id %>
     priority <%= @vrrp_instance_priority %>
+<% if @ipv6_on %>
+    native_ipv6
+<% end %>
 <% if @vrrp_instance_vrrp_unicast_peer.nil? %>
-    ! vrrp_unicast_bind <local ip address>
-    ! vrrp_unicast_peer <peer ip address>
+    ! unicast_bind <local ip address>
+    ! unicast_peer { <peer ip address> }
 <% else %>
-    vrrp_unicast_bind <%= @vrrp_instance_vrrp_unicast_bind %>
-    vrrp_unicast_peer <%= @vrrp_instance_vrrp_unicast_peer %>
+    unicast_srcip <%= @vrrp_instance_vrrp_unicast_bind %>
+    unicast_peer { 
+                <%= @vrrp_instance_vrrp_unicast_peer %>
+    }
 <% end %>
     advert_int <%= @vrrp_instance_advert_int %>
 		notify_backup "/var/opt/opscode/keepalived/bin/cluster.sh backup"

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-keepalived-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-keepalived-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -P /opt/opscode/embedded/sbin/keepalived --log-console --log-detail --dont-fork --use-file=<%= File.join(node["private_chef"]["keepalived"]["dir"], "etc", "keepalived.conf") %>
+exec chpst -P /opt/opscode/embedded/sbin/keepalived --log-console --log-detail --dump-conf --dont-fork --use-file=<%= File.join(node["private_chef"]["keepalived"]["dir"], "etc", "keepalived.conf") %>


### PR DESCRIPTION
This uses the syntax introduced in 1.2.9 for unicast. Note that keepalived is both limited in the accepted syntax and silently fails back to multicast if the syntax isn't right.

@marcparadise @sdelano @hosh 

A little bit of background:

Keepalived by default uses a multicast protocol to monitor peers. However that isn't routable across networks.
Some customers split their HA boxes across networks as part of their redundancy strategy. We added unicast (aka point to point) connections using a publicly proposed patch to keepalived 1.1.20. In the time between the proposal and final merge into mainstream, the syntax got changed, and our config file became silently broken.

This got missed by our tests for several reasons:
1) keepalived ignores bad syntax and silently uses multicast by default. This works in our test setup because the two backend hosts are on the same network.
2) While we do disable IPv4 networking as part of our IPv6 test setup, we don't disable the dhclient daemons. Eventually the IPv4 address reappears. Usually we have IPv4 back before we've managed to fully complete the setup process, and keepalived may end up silently using IPv4 multicast and not IPv6 multicast (or sometimes a mix of both) So it is not sufficient to check that no multicast IPv6 packets are being sent.

The only reliable way to verify that we are indeed doing the right thing is to tcpdump the output.

There should be no packets going to 224.0.0.18, protocol 112, nor FF02:0:0:0:0:0:0:12, protocol 112.

http://tools.ietf.org/search/rfc3768
