### PR TITLE
Restrict darklaunch data insertion to only run on the live redis host

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -74,6 +74,7 @@ end
 ruby_block "set_lb_redis_values" do
   retries 5
   retry_delay 1
+  only_if { is_data_master? }
   block do
     require "redis"
     redis = Redis.new(:host => redis_data.vip, :port => redis_data.port)


### PR DESCRIPTION
We initialize darklaunch data for redis in the redis lb cookbook.

Redis is only available on a single host, and while we could remotely
access it, it doesn't make sense to update it more than once anyways.

Eventually we should consider making this a migration instead, since it
probably shouldn't be done on every reconfigure.

This successfully passes CI and manual HA testing.

@marcparadise @seth @sdelano @oferrigni 
