### PR TITLE
Turn off request logging in bookshelf

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -84,12 +84,15 @@
              ]},
   {webmachine, [
           {log_handlers, [
-               {oc_wm_request_logger, [
-                       {file, "<%= File.join(@log_directory, 'requests.log') %>"},
-                       {file_size, 100},  %% Size in MB
-                       {files, 5},
-                       {annotations, [user, req_id]}
-                       ]
-               }]
+%%% Log handling is disabled, because it is redundant (nginx also logs requests)
+%%% If debug logging is needed, this can be uncommented to start logging somewhat verbose logs
+%%%              {oc_wm_request_logger, [
+%%%                       {file, "<%= File.join(@log_directory, 'requests.log') %>"},
+%%%                       {file_size, 100},  %% Size in MB
+%%%                       {files, 5},
+%%%                       {annotations, [user, req_id]}
+%%%                       ]
+%%%               }
+                         ]
           }]}
 ].


### PR DESCRIPTION
This turns off bookshelf request logging. This formalizes what we tried in the load test system.

@sdelano @oferrigni @tylercloke  @marcparadise 
Passes CI http://andra.ci.opscode.us/job/private-chef-trigger-ad-hoc/632
