### PR TITLE
Add libossp-uuid dependency and configure postgres for ossp-uuid extension

### DIFF
--- a/config/software/libossp-uuid.rb
+++ b/config/software/libossp-uuid.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libossp-uuid"
+version "1.6.2"
+
+dependency "autoconf"
+dependency "automake"
+
+source :url => "ftp://ftp.ossp.org/pkg/lib/uuid/uuid-1.6.2.tar.gz",
+       :md5 => "5db0d43a9022a6ebbbc25337ae28942f"
+
+relative_path "uuid-1.6.2"
+
+build do
+  env = {
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+  }
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           ].join(" "),
+          :env => env)
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin"}
+  command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin"}
+end

--- a/config/software/postgresql92.rb
+++ b/config/software/postgresql92.rb
@@ -22,6 +22,7 @@ dependency "zlib"
 dependency "openssl"
 dependency "libedit"
 dependency "ncurses"
+dependency "libossp-uuid"
 
 source :url => "http://ftp.postgresql.org/pub/source/v9.2.4/postgresql-9.2.4.tar.bz2",
        :md5 => "6ee5bb53b97da7c6ad9cb0825d3300dd"
@@ -39,6 +40,7 @@ build do
            "--prefix=#{install_dir}/embedded/postgresql/9.2",
            "--with-libedit-preferred",
            "--with-openssl",
+           "--with-ossp-uuid",
            "--with-includes=#{install_dir}/embedded/include",
            "--with-libraries=#{install_dir}/embedded/lib"].join(" "), :env => configure_env
   command "make world -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}


### PR DESCRIPTION
Enable the ossp-uuid extension for creating uuid objects natively inside postgres.

We use this inside actionlog
