### PR TITLE
Jc/add actionlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 11.1.2
 
+### oc_erchef
+* oc\_erchef 0.24.0 - add oc\_chef\_action to oc\_erchef
+
 ### posgresql
 * Add ossp-uuid extension to Postgres 9.2
 

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-version "0.23.0"
+version "0.24.0"
 
 dependency "erlang"
 dependency "rebar"


### PR DESCRIPTION
This bumps oc_erchef to 0.24.0.

note, the HEAD commit of this is a temporary override to point oc_erchef at the branch for testing.  This commit (f03e23d) will not be merged.
