### PR TITLE
Security: tell opscode-certificate to listen on localhost by default. 

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-certificate-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-certificate-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME="<%= node['private_chef']['opscode-certificate']['dir'] %>" /opt/opscode/embedded/service/opscode-certificate/start.sh
+exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME="<%= node['private_chef']['opscode-certificate']['dir'] %>" WEBMACHINE_IP="<%= node['private_chef']['opscode-certificate']['vip'] %>" /opt/opscode/embedded/service/opscode-certificate/start.sh


### PR DESCRIPTION
Use the node['private_chef']['opscode-certificate']['vip'] attribute, which opscode-erchef uses to find it.

Result of the Nordstrom 02/2014 Pen-Test response. 
