### PR TITLE
Remove redundant "Topology" line from show_config output.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/show_config.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/show_config.rb
@@ -11,5 +11,4 @@ if File.exists?("/etc/opscode/private-chef.rb")
 end
 config = PrivateChef.generate_config(node['fqdn'])
 
-puts "Topology: #{PrivateChef['topology']}"
 puts Chef::JSONCompat.to_json_pretty(config)


### PR DESCRIPTION
The topology is already included in the json output.
