### PR TITLE
Remove incorrect mention of heartbeat_device.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Increase postgresql max_connections to 350 to handle 4 node cluster
 * Manage permissions for /var/log/opscode for non 0022 umasks
 
+### private-chef-ctl
+* Remove incorrect mention of `heartbeat_device` from `ha-status` output.
+
 ## 11.1.2 (2014-02-28)
 
 ### posgresql

--- a/files/private-chef-ctl-commands/ha.rb
+++ b/files/private-chef-ctl-commands/ha.rb
@@ -100,7 +100,7 @@ add_command "ha-status", "Show the status of high availability services.", 1 do
   if has_vrrp_instance_interface
     puts "[OK] found VRRP communications interface #{vrrp_instance_interface}"
   else
-    puts "[ERROR] VRRP communications interface #{vrrp_instance_interface} not found, is heartbeat_device set correctly in private-chef.rb?"
+    puts "[ERROR] VRRP communications interface #{vrrp_instance_interface} not found."
     error_exit = 8
   end
 


### PR DESCRIPTION
The heartbeat_device was removed in the following commit:

  517026cdf7fd10e63f3675d8c8d0e6c9961cbfb3

VRRP hearbeating now happens over the interface specifed as the
"device" for the backend_vip.
