### PR TITLE
The nginx postrotate command doesnt work as found at Disney, 

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -168,7 +168,7 @@ template "/etc/opscode/logrotate.d/nginx" do
   group "root"
   mode "0644"
   variables(node['private_chef']['nginx'].to_hash.merge(
-    'postrotate' => "/opt/opscode/embedded/sbin/nginx -s reopen",
+    'postrotate' => 'kill -USR1 `cat /opt/opscode/service/nginx/supervise/pid`',
     'owner' => 'root',
     'group' => 'root'
   ))


### PR DESCRIPTION
but this version is correct via http://wiki.nginx.org/LogRotation and tested (at Disney, in Production)
