### PR TITLE
OC-11490 Explicitly set keepalived directory ownership

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/keepalived.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/keepalived.rb
@@ -10,11 +10,18 @@ keepalived_etc_dir = File.join(keepalived_dir, "etc")
 keepalived_bin_dir = File.join(keepalived_dir, "bin")
 keepalived_log_dir = node['private_chef']['keepalived']['log_directory']
 
-[ keepalived_dir, keepalived_etc_dir, keepalived_bin_dir, keepalived_log_dir ].each do |dir|
+[ keepalived_dir, keepalived_etc_dir, keepalived_bin_dir ].each do |dir|
   directory dir do
+    owner "root"
     recursive true
     mode "0755"
   end
+end
+
+directory keepalived_log_dir do
+  owner node['private_chef']['user']['username']
+  recursive true
+  mode "0700"
 end
 
 template File.join(keepalived_etc_dir, "keepalived.conf") do


### PR DESCRIPTION
Keeaplived's svlogd runs as the opscode user but cannot
write to log files in /var/log/opscode/keepalived because
the directory is owned by root.

This prevents keepalived from running properly.
