### PR TITLE
Bump opscode-platform-debug to rel-0.4.6 from 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 * check org _route endpoint for groups darklaunch during org creation
 * fix schema constraint bug during LDAP user creation
 
+### opscode-platform-debug rel-0.4.6
+* Remove legacy chargify code
+* Updated knifetests to work with the latest reporting API
+
 ### opscode-webui 3.8.13
 * Ruby on Rails security updates
 

--- a/config/software/opscode-platform-debug.rb
+++ b/config/software/opscode-platform-debug.rb
@@ -1,5 +1,5 @@
 name "opscode-platform-debug"
-default_version "rel-0.4.4"
+default_version "rel-0.4.6"
 
 dependency "ruby"
 dependency "bundler"


### PR DESCRIPTION
Ship @manderson26's small change to remove legacy chargify code plus the last version that wasn't shipped that contained test updates (according to tag description) cc/ @sdelano 
