### PR TITLE
increase s3_url_ttl from 15m to 8h

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -153,7 +153,7 @@ default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 # Default: generate signed URLs based upon Host: header. Override with a url, "http:// ..."
 default['private_chef']['opscode-erchef']['base_resource_url'] = :host_header
 default['private_chef']['opscode-erchef']['s3_bucket'] = 'bookshelf'
-default['private_chef']['opscode-erchef']['s3_url_ttl'] = 900
+default['private_chef']['opscode-erchef']['s3_url_ttl'] = 28800
 default['private_chef']['opscode-erchef']['s3_parallel_ops_timeout'] = 5000
 default['private_chef']['opscode-erchef']['s3_parallel_ops_fanout'] = 20
 default['private_chef']['opscode-erchef']['authz_timeout'] = 1000


### PR DESCRIPTION
tired of endless CHEF-3045 complaints on the mailing list.

403s on long chef runs are not delightful.

any attacker than can issue a replay attack inside of an 8 hour window
can also issue a replay attack within a 15 minute window, so having this
timeout be shorter does not prevent any attacks (15 minutes is already
an eternity to any kind of automated attack tool).
