### PR TITLE
PrivateChef['lb']['upstream'] should allow custom settings through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Enterprise Chef Changelog
 
+## 11.1.6 (Unreleased)
+
+### private-chef-cookbooks
+* Allow ['lb']['upstream'] to have a custom setting
+
 ## 11.1.5 (2014-05-14)
 
 ### oc_erchef 0.24.6

--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -360,7 +360,7 @@ module PrivateChef
       PrivateChef["postgresql"]["enable"] ||= false
       PrivateChef["postgresql"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
       PrivateChef["lb"]["cache_cookbook_files"] ||= true
-      PrivateChef["lb"]["upstream"] = Mash.new
+      PrivateChef["lb"]["upstream"] ||= Mash.new
       if PrivateChef["use_ipv6"] && PrivateChef["backend_vips"]["ipaddress"].include?(':')
         PrivateChef["lb"]["upstream"]["bookshelf"] ||= [ "[#{PrivateChef["backend_vips"]["ipaddress"]}]" ]
       else


### PR DESCRIPTION
If someone wants to modify PrivateChef["lb"]["upstream"] , we should let them.
When it looks like this: PrivateChef["lb"]["upstream"] = Mash.new , any custom value is always overwritten.
