### PR TITLE
initial pass: users endpoint in oc_erchef

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-default_version "1.0.42"
+default_version "1.0.45"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-default_version "0.25.14"
+default_version "0.25.17"
 
 dependency "erlang"
 dependency "rebar"

--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -44,7 +44,7 @@ template erchef_config do
   owner owner
   group group
   mode "644"
-  variables(node['private_chef']['opscode-erchef'].to_hash.merge({:helper => OmnibusHelper.new(node)}))
+  variables(node['private_chef']['opscode-erchef'].to_hash.merge(:ldap_enabled => ldap_authentication_enabled?, :helper => OmnibusHelper.new(node)))
   notifies :run, 'execute[remove_erchef_siz_files]', :immediately
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?
 end

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
@@ -101,8 +101,19 @@ local p_erchef_endpoint = p_cookbooks + p_data + p_roles + p_sandboxes +
 local p_erchef_direct = (Cendpoint(p_erchef_endpoint) * ((p_sep * c_identifier) + (p_maybe_sep * p_eol))) +
                         Cendpoint(p_search)
 
+-- users endpoint is currently split between erchef and account.
+-- /users, /users/USERNAME/ -> erchef
+-- /verify_password, /authenticate_user, and /system_recover go toaccount, soon to be erchef.
+-- /users/USERNAME/organizations, /users/USERNAME/association_requests go to account
+local p_erchef_users = (p_sep * Cendpoint(p_users) * p_trailing_sep) +
+                       (p_sep * Cendpoint(p_users) * (p_sep * c_identifier)^-1 * p_trailing_sep) +
+                       (p_sep * Cendpoint(p_auth_user) * p_trailing_sep)
+-- TODO future: +
+--        (p_sep * Cendpoint(p_verify_password + p_auth_user + p_system_recovery) * p_trailing_sep)
+
 -- Everything that gets sent to erchef
-local p_erchef = p_named_org_prefix * p_erchef_direct
+local p_erchef = (p_named_org_prefix * p_erchef_direct) +
+                 p_erchef_users
 
 -- erchef routing rules for chef_internal, which includes an additional
 -- principals endpoint not exposed via the api rules
@@ -111,7 +122,8 @@ local p_erchef_int = p_erchef +
 
 -- /users endpoints for account:
 local p_named_user = (p_sep * p_users * p_sep * c_identifier)
-local p_acct_users = (p_sep * Cendpoint(p_users) * (p_sep * c_identifier)^-1 * p_trailing_sep) +
+local p_acct_users = (p_named_org_prefix * Cendpoint(p_users) * (p_sep + p_eol)) +
+                     (p_sep * Cendpoint(p_users) * (p_sep * c_identifier)^-1 * p_trailing_sep) +
                       p_named_user *
                           -- below rule for backwards compatibility with original:
                           -- /users/BLAH/{0,1}/association_requests
@@ -124,9 +136,9 @@ local p_acct_users = (p_sep * Cendpoint(p_users) * (p_sep * c_identifier)^-1 * p
 local p_acl_endpoint = (p_named_org_prefix * p_all_until_acl * Cendpoint(p_acl) * (p_sep + p_eol)) +
                        (p_named_user * Cendpoint(p_acl) * (p_sep + p_eol))
 local p_acct_direct = Cendpoint(p_users + p_association_requests) * (p_sep + p_eol)
-local p_acct = (p_sep * Cendpoint(p_verify_password + p_auth_user + p_system_recovery) * p_eol) +
-               (p_named_org_prefix * p_acct_direct) +
+local p_acct = (p_named_org_prefix * p_acct_direct) +
                (p_sep * Cendpoint(p_org) * (p_sep * Cg(p_org_identifier, "org_name"))^-1 * p_trailing_sep) +
+               (p_sep * Cendpoint(p_verify_password + p_system_recovery) * p_trailing_sep) +
                p_acct_users
 
 local uri_resolvers = {
@@ -136,7 +148,6 @@ local uri_resolvers = {
   api = (p_acl_endpoint * c_acct) +
         (p_erchef * c_erchef) +
         (p_acct * c_acct),
-
 
   -- This one is easy - everything passes through, though we'll still need to capture components
   -- (org name, object name, endpoint name) where we can, so that post-route hooks can be applied.
@@ -151,6 +162,7 @@ local uri_resolvers = {
                   -- we will need to continue to add migrated acct->erchef endpoints here
                   -- until we either correct or retire webui 1
                   ((p_named_org_prefix * Cendpoint(p_clients) * c_maybe_identifier) * c_erchef) +
+                  (p_erchef_users * c_erchef) +
                   ((p_acct +
                    (p_named_org + p_sep)) * c_acct),
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -73,15 +73,29 @@
               %% how many nodes are deserialized at a time in
               %% preparing a response.
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
-	      {superusers, [<<"pivotal">>]},
+	          {superusers, [<<"pivotal">>]},
               %% metrics config
               {root_metric_key, "<%= @root_metric_key %>"},
 
               {authz_timeout, <%= node['private_chef']['opscode-erchef']['authz_timeout'] %>},
               {authz_fanout, <%= node['private_chef']['opscode-erchef']['authz_fanout'] %>},
 
-              {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>}
-             ]},
+              {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>},
+              <% if @ldap_enabled -%>
+              {ldap, [{enabled, <%= @ldap_enabled %>},
+                      {host, "<%=node['private_chef']['ldap']['host'] || "localhost" %>"},
+                      {port, <%= node['private_chef']['ldap']['port'] || "389" %> },
+                      {timeout, <%= node['private_chef']['ldap']['timeout'] || "60000" %> },
+                      {bind_dn, "<%= node['private_chef']['ldap']['bind_dn'] || "" %>" },
+                      {bind_password, "<%= node['private_chef']['ldap']['bind_password'] || "" %>" },
+                      {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
+                      {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },
+                      {encryption, <%= node['private_chef']['ldap']['ssl_enabled'] || false %> }
+              ]}
+              <% else -%>
+              {ldap, []}
+              <% end -%>
+            ]},
   {chef_wm, [
              {max_request_size, <%= node['private_chef']['opscode-erchef']['max_request_size'] %>},
              {server_version, "<%= node['private_chef']['version'] %>"},

--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -147,7 +147,7 @@ ruby_data_endpoint?        false
 ruby_role_endpoint?        false
 ruby_cookbook_endpoint?    false
 ruby_client_endpoint?      false
-ruby_users_endpoint?       true
+ruby_users_endpoint?       false
 ruby_container_endpoint?   false
 ruby_container_endpoint_in_sql? true
 ruby_group_endpoint?       false


### PR DESCRIPTION
- includes users endpoint support in erchef
- support in underyling components for oc_chef_wm requests
  that do not have a valid org, without stubbing out org.
- make oc_erchef aware of global containers in couch
- nginx routing for endpoints

/ping @opscode/server-team

Note that I'm leaning towards maintaining this as a feature branch
pending completion of other works in progress.
