### PR TITLE
Ship containers and groups migration to EC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 * Allow ['lb']['upstream'] to have a custom setting
 * Use SSL port for lb_internal if non-SSL is disabled
 
+### chef-mover 2.2.4
+* Containers and groups migration from couchDB to postgreSQL
+* Solr4 migration
+* Generalized migrate scripts and other code to be migration_type agnostic
+
+### enterprise-chef-server-schema 2.2.5
+* Updates org_migration_state table with migration_type and verification
+* Cleans up reporting schema info table
+* Clean up Makefile to preserve PATH variable
+
 ## 11.1.5 (2014-05-14)
 
 ### oc_erchef 0.24.6

--- a/config/software/enterprise-chef-server-schema.rb
+++ b/config/software/enterprise-chef-server-schema.rb
@@ -1,5 +1,5 @@
 name "enterprise-chef-server-schema"
-default_version "2.2.3"
+default_version "2.2.5"
 
 source :git => "git@github.com:opscode/enterprise-chef-server-schema.git"
 

--- a/config/software/opscode-chef-mover.rb
+++ b/config/software/opscode-chef-mover.rb
@@ -1,5 +1,5 @@
 name "opscode-chef-mover"
-default_version "1.1.3"
+default_version "2.2.4"
 
 dependency "erlang"
 dependency "rebar"

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -162,6 +162,7 @@ default['private_chef']['opscode-erchef']['root_metric_key'] = "chefAPI"
 default['private_chef']['opscode-erchef']['depsolver_worker_count'] = 5
 default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['max_request_size'] = 1000000
+default['private_chef']['opscode-erchef']['cleanup_batch_size'] = 0
 
 ###
 # Legacy path (required for cookbok migration)
@@ -264,8 +265,8 @@ default['private_chef']['lb']['chef_max_version'] = 11
 # Load balancer route configuration
 ###
 default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = true
-default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = true
+default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
 
 ####
 # Nginx
@@ -491,6 +492,14 @@ default['private_chef']['opscode-chef-mover']['cache_ttl'] = '3600'
 default['private_chef']['opscode-chef-mover']['db_pool_size'] = '5'
 default['private_chef']['opscode-chef-mover']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-chef-mover']['ibrowse_max_pipeline_size'] = 1
+default['private_chef']['opscode-chef-mover']['solr_timeout'] = 30000
+default['private_chef']['opscode-chef-mover']['solr_http_init_count'] = 25
+default['private_chef']['opscode-chef-mover']['solr_http_max_count'] = 100
+default['private_chef']['opscode-chef-mover']['solr_http_cull_interval'] = "{1, min}"
+default['private_chef']['opscode-chef-mover']['solr_http_max_age'] = "{70, sec}"
+default['private_chef']['opscode-chef-mover']['solr_http_max_connection_duration'] = "{70,sec}"
+default['private_chef']['opscode-chef-mover']['solr_ibrowse_options'] = "[{connect_timeout, 10000}]"
+
 
 ###
 # Opscode Test

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
@@ -91,7 +91,8 @@ local c_identifier = Cg(p_identifier, "object_name")
 local c_maybe_identifier = (p_sep * c_identifier)^-1
 
 local p_erchef_endpoint = p_cookbooks + p_data + p_roles + p_sandboxes +
-                          p_environments + p_clients + p_nodes + p_principals
+                          p_environments + p_clients + p_nodes + p_principals +
+			   p_groups + p_containers
 
 -- endpoints that map directly to erchef
 -- If an object identifier is present - as identified with /IDENTIFIER - then
@@ -128,20 +129,13 @@ local p_acct = (p_sep * Cendpoint(p_verify_password + p_auth_user + p_system_rec
                (p_sep * Cendpoint(p_org) * (p_sep * Cg(p_org_identifier, "org_name"))^-1 * p_trailing_sep) +
                p_acct_users
 
---
--- darklaunch endpoints - these need to capture the endpoint name itself for darklaunch resolution
---
-local c_dl_acct_erchef_endpoint = Cendpoint(p_groups + p_containers)
-local p_dl_acct_erchef = p_named_org_prefix * c_dl_acct_erchef_endpoint * c_maybe_identifier
-
 local uri_resolvers = {
   -- Retain ordering to ensure proper eval:
   -- p_acl_endpont must come firs tbecause a trailing _acl takes precedence
   -- over any other identifiers which may be in the url.
   api = (p_acl_endpoint * c_acct) +
         (p_erchef * c_erchef) +
-        (p_acct * c_acct) +
-        (p_dl_acct_erchef * c_acct_erchef),
+        (p_acct * c_acct),
 
 
   -- This one is easy - everything passes through, though we'll still need to capture components
@@ -156,7 +150,6 @@ local uri_resolvers = {
                   -- we have to be able to route migrated endpoints (that used to be acct) to erchef.
                   -- we will need to continue to add migrated acct->erchef endpoints here
                   -- until we either correct or retire webui 1
-                  (p_dl_acct_erchef * c_acct_erchef) +
                   ((p_named_org_prefix * Cendpoint(p_clients) * c_maybe_identifier) * c_erchef) +
                   ((p_acct +
                    (p_named_org + p_sep)) * c_acct),

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -105,7 +105,8 @@
                                  ]},
                 {couchdb_host, "<%= @helper.normalize_host(node['private_chef']['couchdb']['vip']) %>"},
                 {couchdb_port, <%= node['private_chef']['couchdb']['port'] %> },
-                {authz_superuser_id, <<"<%= node['private_chef']['oc_bifrost']['superuser_id'] %>">>}
+                {authz_superuser_id, <<"<%= node['private_chef']['oc_bifrost']['superuser_id'] %>">>},
+                {cleanup_batch_size, <%= node['private_chef']['opscode-erchef']['cleanup_batch_size'] %>}
                ]},
   {chef_db, [
              {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},

--- a/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -91,7 +91,7 @@
            {db_pass, "<%= node['private_chef']['postgresql']['sql_password'] %>"},
            {db_name, "opscode_chef" },
            {idle_check, 10000},
-           {prepared_statements, {chef_sql, opc_statements, [pgsql]}},
+           {prepared_statements, {oc_chef_sql, statements, [pgsql]}},
            {column_transforms,
                               [{<<"created_at">>,
                                 {sqerl_transformers, convert_YMDHMS_tuple_to_datetime}},
@@ -139,5 +139,16 @@
           % If dry_run is true, eredis host and port will be ignored.
           {eredis_host, "127.0.0.1"},
           {eredis_port, 16379}
+         ]},
+ {chef_reindex, [
+          {solr_service, [{root_url, "<%= node['private_chef']['opscode-solr']['url'] %>"},
+                          {timeout, <%= @solr_timeout %>},
+                          {init_count, <%= @solr_http_init_count %>},
+                          {max_count, <%= @solr_http_max_count %>},
+                          {cull_interval, <%= @solr_http_cull_interval %>},
+                          {max_age, <%= @solr_http_max_age %>},
+                          {max_connection_duration, <%= @solr_http_max_connection_duration %>},
+                          {ibrowse_options, <%= @solr_ibrowse_options %>}]
+          }
          ]}
 ].

--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -148,9 +148,9 @@ ruby_role_endpoint?        false
 ruby_cookbook_endpoint?    false
 ruby_client_endpoint?      false
 ruby_users_endpoint?       true
-ruby_container_endpoint?   <%= node['private_chef']['lb']['xdl_defaults']['couchdb_containers'] %>
-ruby_container_endpoint_in_sql?  <%= !node['private_chef']['lb']['xdl_defaults']['couchdb_containers'] %>
-ruby_group_endpoint?       <%= node['private_chef']['lb']['xdl_defaults']['couchdb_groups'] %>
+ruby_container_endpoint?   false
+ruby_container_endpoint_in_sql? true
+ruby_group_endpoint?       false
 
 old_runlists_and_search true
 

--- a/files/private-chef-upgrades/001/014_upgrade_migration_schema.rb
+++ b/files/private-chef-upgrades/001/014_upgrade_migration_schema.rb
@@ -1,0 +1,14 @@
+define_upgrade do
+
+  if Partybus.config.bootstrap_server
+
+    must_be_data_master
+
+    # run 2.2.4 migration which includes schema upgrade for migration state
+    run_command("make deploy",
+                :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema",
+                :env => {"EC_TARGET" => "@2.2.4", "OSC_TARGET" => "@1.0.4", "DB_USER" => "opscode-pgsql"}
+                )
+
+  end
+end

--- a/files/private-chef-upgrades/001/015_chef_mover_phase_2.rb
+++ b/files/private-chef-upgrades/001/015_chef_mover_phase_2.rb
@@ -1,0 +1,79 @@
+# This is the chef-mover `phase_2_prep_migration` and `phase_2_migration`
+# that migrates containers and groups from couchDB to postgreSQL
+
+require 'time'
+
+define_upgrade do
+  if Partybus.config.bootstrap_server
+
+    must_be_data_master
+
+    # Shut down everything but couch & postgres
+    down_services = ['nginx',
+                     'opscode-org-creator',
+                     'bookshelf',
+                     'oc_bifrost',
+                     'opscode-account',
+                     'opscode-certificate',
+                     'opscode-erchef',
+                     'opscode-expander',
+                     'opscode-expander-reindexer',
+                     'opscode-solr',
+                     'opscode-webui',
+                     'opscode-rabbitmq']
+
+    down_services.each{|s| run_command("private-chef-ctl stop #{s}")}
+
+    # delete pre-created orgs
+    run_command("/opt/opscode/embedded/bin/ruby scripts/delete-pre-created-orgs.rb /etc/opscode/orgmapper.conf all",
+                :cwd => "/opt/opscode/embedded/service/opscode-platform-debug/orgmapper",
+                :env => {"RUBYOPT" => "-I/opt/opscode/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib"})
+
+    # Move any mover log files from a previous run, if they exist.
+    # The log message parser requires a "clean slate".
+    current_time = Time.now.utc.iso8601
+    mover_log_file_glob = "/var/log/opscode/opscode-chef-mover/console.log*"
+    parsed_log_output = "/var/log/opscode/opscode-chef-mover/parsed_console.log"
+    run_command("mkdir /var/log/opscode/opscode-chef-mover/#{current_time}")
+    begin
+      run_command("mv #{mover_log_file_glob} /var/log/opscode/opscode-chef-mover/#{current_time}")
+    rescue
+      log "No files found at #{mover_log_file_glob}. Moving on..."
+    end
+
+    begin
+      run_command("mv #{parsed_log_output} /var/log/opscode/opscode-chef-mover/#{current_time}")
+    rescue
+      log "#{parsed_log_output} not found. Moving on..."
+    end
+
+    ####
+    #### perform a migration similar to what we did for hosted chef following this plan
+    #### github.com/opscode/chef-mover/blob/024875c5545a0e7fb62c0852d4498d2ab7dd1c1d/docs/phase-2-migration-plan.md
+    ####
+
+    # Bring up chef-mover for the duration of the migration
+    log "Firing up chef-mover, this could take a minute..."
+    run_command("private-chef-ctl restart opscode-chef-mover")
+    sleep(60)
+
+    # Run phase_2_migration
+    log "Migrating containers and groups..."
+    run_command("/opt/opscode/embedded/bin/escript " \
+                "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate mover_phase_2_migration_callback normal")
+
+    # We don't need chef-mover anymore
+    run_command("private-chef-ctl stop opscode-chef-mover")
+
+    # Clean up chef_*.couch files, we don't need them anymore! (should already be backed up too)
+    log "Cleaning up containers and groups from couchDB..."
+    run_command("find /var/opt/opscode/couchdb/db -name 'chef_*.couch' | xargs rm")
+    run_command("rm -rf /var/opt/opscode/couchdb/db/.chef_*_design")
+
+    # Bring everything back up
+    log "Restarting chef services..."
+    down_services.reverse.each{|s| run_command("private-chef-ctl start #{s}")}
+
+    log "Containers and groups migration complete!"
+  end
+end


### PR DESCRIPTION
Ship containers and groups migration to EC.

Ping @opscode/server-team 

Depends on:
- https://github.com/opscode/enterprise-chef-server-schema/pull/11
- https://github.com/opscode/chef-mover/pull/57

TODO to resolve before merge:
- [x] Should we change the mover config to set dry_run to false by default? It is needed for the `phase_2_prep_migration`. Lets not use `phase_2_prep_migration` for this.
- [x] Is an `upgrade_schema_to` definition required for my schema upgrade? **NO**
- [x] Should the 014 and 015 partybus upgrades I proposed be one upgrade?
  
  ```
  From @sdelano:
  No. The migrations files are long enough already. This breaks them up nicely.
  ```
- [x] Do we need to tweak the nginx config per @marcparadise's comment?
  
  ```
  From @sdelano:
  Yes, we should do this work. @marcparadise is correct, we won't need the load balancer switching because all requests should go to oc_erchef.
  ```
- [x] Can / should we delete the chef_GUID couch files?
  
  ```
  From @sdelano:
  Yes we should delete these files.  
  ```
- [x] Remove phase_2_prep_migration from scripts.
- [x] Clean up .chef_*_design?
- [x] Test that manage routing works post-migration.
- [x] Merge mover and schema PRs from the top of this readme.
- [x] Comment 1 https://github.com/opscode/opscode-omnibus/pull/290#discussion_r12968187
- [x] Comment 2 https://github.com/opscode/opscode-omnibus/pull/290#discussion_r12968596
- [x] Cut new version of mover.
- [x] Pull in mover and schema releases.
- [x] Run build through CI and test migrations with `private-chef-clt upgrade`.
- [ ] Finish updating changelog.
