### PR TITLE
Introduce a 2-minute sleep between the reconfigure and partybus steps.

### DIFF
--- a/files/private-chef-ctl-commands/upgrade.rb
+++ b/files/private-chef-ctl-commands/upgrade.rb
@@ -8,7 +8,7 @@ add_command "upgrade", "Upgrade your private chef installation.", 1 do
   reconfigure(false)
   Dir.chdir(File.join(base_path, "embedded", "service", "partybus"))
   bundle = File.join(base_path, "embedded", "bin", "bundle")
-  status = run_command("#{bundle} exec ./bin/partybus upgrade")
+  status = run_command("echo 'Sleeping for 2 minutes before migration' ; sleep 120 ; #{bundle} exec ./bin/partybus upgrade")
   if status.success?
     puts "Chef Server Upgraded!"
     exit 0


### PR DESCRIPTION
This gives the services a chance to finish starting/restarting and settle down.  This has proven to massively improve the reliability of upgrades in the field and is recommend in the upgrade notes: http://docs.opscode.com/upgrade_server_ha_notes.html#upgrade-rb
