### PR TITLE
Add a sanity check for missing/corrupt migration-level files.  Don't let...

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
@@ -67,7 +67,7 @@ EOF
       raise message
     end
   end
-  not_if 'ls /var/opt/opscode/upgrades/migration-level'
+  not_if 'test -f /var/opt/opscode/upgrades/migration-level'
   action :nothing
   subscribes :run, 'private-chef_pg_upgrade[upgrade_if_necessary]', :delayed
 end


### PR DESCRIPTION
... upgrades proceed without this file.  Also help the partybus init stage run even if /var/opt/opscode was already created

Some history on this issue:
- Very frequently in HA installs the migration-level file is missing because HA installs are interrupted by customers as prompted during the DRBD setup phase.
  - Ref: http://docs.opscode.com/upgrade_server_ha_notes.html#pre-flight-check
- We can't be any more cavalier about running `partybus init` because migration steps will get skipped if the package has already been upgraded.
- As documented in the JIRA ticket, this is a common cause of upgrade issues and customer frustration.
