### PR TITLE
set SVWAIT=30 for all private-chef-ctl commands,

### DIFF
--- a/config/software/private-chef-ctl.rb
+++ b/config/software/private-chef-ctl.rb
@@ -16,6 +16,8 @@ build do
 # All Rights Reserved
 #
 
+export SVWAIT=30
+
 # Ensure the calling environment (disapproval look Bundler) does not infect our
 # Ruby environment if private-chef-ctl is called from a Ruby script.
 for ruby_env_var in RUBYOPT \\


### PR DESCRIPTION
 the default SVWAIT timeout of 7 seconds is too short and causes many unnecesary failures during reconfigure and upgrade.
