### PR TITLE
use berkshelf2 software config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: ce4512b6761aca57b68db34648ba4bf684789d7d
+  revision: 4d3042943bd8c92a0d9fd7f0785ae0a95aa283b9
   specs:
     omnibus-software (0.0.1)
 

--- a/config/projects/private-chef.rb
+++ b/config/projects/private-chef.rb
@@ -7,7 +7,6 @@ install_path    "/opt/opscode"
 build_version   Omnibus::BuildVersion.new.semver
 build_iteration 1
 
-override :berkshelf, version: "v2.0.15"
 override :rebar, version: "2.0.0"
 
 # creates required build directories

--- a/config/software/private-chef-cookbooks.rb
+++ b/config/software/private-chef-cookbooks.rb
@@ -1,6 +1,6 @@
 name "private-chef-cookbooks"
 
-dependency "berkshelf"
+dependency "berkshelf2"
 
 project_name = project.name
 


### PR DESCRIPTION
The berkshelf software config drifted and is catered to
installing berkshelf from master and at versions > 3. We're
still using berkshelf 2 here, and as such we don't need it
to depend on gecode. I've ported the pre-berks-3 version
of the berkshelf software config and named it berkshelf2.

This should fix the failing builds on centos5.
