### PR TITLE
Make the API serve an index page to web clients

### DIFF
--- a/files/private-chef-cookbooks/private-chef/files/default/html/400-chef_client_manage.json
+++ b/files/private-chef-cookbooks/private-chef/files/default/html/400-chef_client_manage.json
@@ -1,1 +1,1 @@
-{ "error": "400 - Bad Request: Chef Client can not access web console, use api.opscode.com." }
+{ "error": "400 - Bad Request: Chef Client can not access the Management Console." }

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -29,8 +29,13 @@
     error_page 404 =404 /404.html;
     error_page 503 =503 /503.json;
 
-    # error doc requests should not be routed through the lua routing below.
-    location ~ "^/[0-9]{3,3}\.(json|html)$" {
+    # Whitelist the docs necessary to serve up error pages and friendly
+    # html to non-chef clients hitting this host.
+    location ~ "^/[0-9]{3,3}\.(json|html)|index.html$" {
+    }
+    location "/css/" {
+    }
+    location "/images/" {
     }
 
     location /version {

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
@@ -35,13 +35,19 @@ if mode == "api" then
   -- Internal API does not validate chef version
   if not internal then
     -- Exit early: If they don't have the right chef version, send them packing.
-    local version = ngx.var.http_x_chef_version or "unknown"
-    if not routes.is_client_version_valid(version, min_version, max_version) then
-      ngx.status = ngx.HTTP_BAD_REQUEST
-      ngx.say('{"error": "400 - Bad Request: Chef Client version between ' ..
-              min_version .. ' and  ' .. max_version ..
-              '" required. Your version of Chef is ' .. version .. '."}')
-      ngx.exit(ngx.HTTP_OK)
+    local version = ngx.var.http_x_chef_version
+    if version then
+      if not routes.is_client_version_valid(version, min_version, max_version) then
+        ngx.status = ngx.HTTP_BAD_REQUEST
+        ngx.say('{"error": "400 - Bad Request: Chef Client version between ' ..
+                min_version .. ' and  ' .. max_version ..
+                '" required. Your version of Chef is ' .. version .. '."}')
+        ngx.exit(ngx.HTTP_OK)
+      end
+    else
+      -- the request did not originate with a chef client, we'll give something
+      -- more friendly to web browsers.
+      return ngx.exec("/index.html")
     end
   end
 


### PR DESCRIPTION
Currently (since the webui code was removed), when you access the running server URL in a browser you get:

``` json
{"error": "400 - Bad Request: Chef Client version between 10 and  11" required. Your version of Chef is unknown."}
```

This changes the behavior of dispatch.lua to match HEC (see https://github.com/opscode/opscode-platform-cookbooks/blob/676d42529b2596cad723d132333888b6ef5323fd/cookbooks/opscode-lb/templates/default/nginx/scripts/dispatch.lua.erb#L27-L40) and makes it so requests without X-Chef-Version headers get served up index.html instead of that 400 JSON message.

It also makes it so the assets (stylesheets and images) for the index page and error pages (you can see one by going to /404.html) get served correctly.

It also changes the text of the message you get when trying to access manage URLs from chef clients to not reference api.opscode.com. 
