### PR TITLE
use port in host header if needed

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
@@ -6,6 +6,20 @@ class NginxErb
     @node = node
   end
 
+  # Sets up the variable used for the host header. If we're running on a
+  # non-standard port (80 for http; 443 for https), we need to include the
+  # port number in the host header, or redirects will not work because we will
+  # lose the port number on the redirect.
+  def host_header_var(proto)
+    if proto == 'http'
+      standard_port = 80
+      port = node['private_chef']['nginx']['non_ssl_port'] || standard_port
+    elsif proto == 'https'
+      standard_port = 443
+      port = node['private_chef']['nginx']['ssl_port'] || standard_port
+    end
+    "$host#{':$server_port' if port != standard_port}"
+  end
 
   def listen_port(proto, options = {})
     listen_port = ""

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -17,7 +17,7 @@
     root <%= File.join(@dir, "html") %>;
     client_max_body_size <%= @client_max_body_size %>;
 
-    proxy_set_header Host $host;
+    proxy_set_header Host <%= @helper.host_header_var(@server_proto) %>;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto <%= @x_forwarded_proto %>;


### PR DESCRIPTION
If you set `nginx['ssl_port']` to anything other than 80 or 443, redirects do not work correctly because the host header does not include the port.

This applies to both webui1 and manage, and is the case both on current master (with webui1 removed) and 11.1 stable.
