### PR TITLE
add override upstream nginx behavior

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -51,6 +51,11 @@
       proxy_pass http://opscode_erchef;
     }
 
+    # This variable is set to an empty string here so it can be used in
+    # dispatch.lua later on. An add-on can set this variable to be used as an
+    # upstream if we determine the request was not intended to go to the API.
+    set $add_on_override_upstream "";
+
     # Include external routes for addons
     include <%= node['private_chef']['nginx']['dir'] %>/etc/addon.d/*_external.conf;
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
@@ -24,6 +24,14 @@ local uri = ngx.var.uri
 -- A couple of early-exit validations that are specific
 -- to an api vhost:
 if mode == "api" then
+  -- If we've defined an override upstream and we don't have a userid, use
+  -- the override upstream.
+  local override_upstream = ngx.var.add_on_override_upstream
+  if userid == "" and override_upstream ~= "" then
+    ngx.var.upstream = override_upstream
+    return
+  end
+
   -- Internal API does not validate chef version
   if not internal then
     -- Exit early: If they don't have the right chef version, send them packing.


### PR DESCRIPTION
This makes it so an add-on can `set $add_on_override_upstream "my_upstream"` and we will use it if we encounter a request without a user header.
