### PR TITLE
Create symlinks for customha scripts if configured

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/keepalived.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/keepalived.rb
@@ -42,4 +42,14 @@ template File.join(keepalived_bin_dir, "cluster.sh") do
   notifies :restart, 'runit_service[keepalived]'
 end
 
+if PrivateChef.ha_provider
+  script_dir = "/opt/chef-ha/bin"
+  ['custom_backend_ip', 'custom_backend_storage'].each do |script|
+    link "#{keepalived_bin_dir}/#{script}" do
+      to "#{script_dir}/#{script}_#{PrivateChef.ha_provider}"
+      only_if { File.exist?("#{script_dir}/#{script}_#{PrivateChef.ha_provider}") }
+    end
+  end
+end
+
 component_runit_service "keepalived"


### PR DESCRIPTION
If you specify ha_provider in private-chef.rb, and the chef-ha addon is
installed, then a private-chef-ctl reconfigure will create symlinks in the
keepalived_bin_dir from the custom_backend_X scripts called by cluster.sh to
the chef-ha scripts provided by the addon.
