### PR TITLE
add back opscode_webui mash

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -27,6 +27,10 @@ module PrivateChef
   opscode_erchef Mash.new
   # Need old path for cookbook migration:
   opscode_chef Mash.new
+  # This is here so legacy private-chef.rb config files that contain settings
+  # like `opscode_webui['enable'] = false` do not break the reconfigure. It is
+  # not used for anything else.
+  opscode_webui Mash.new
   lb Mash.new
   lb_internal Mash.new
   postgresql Mash.new


### PR DESCRIPTION
Put the `opscode_webui` Mash that was removed back.

See https://github.com/opscode/opscode-omnibus/commit/f22c1f111e94751f5b1d02227390fa10fe964478#commitcomment-6748203

/cc @schisamo @sdelano 
