### PR TITLE
Set correct maintainer and homepage.

### DIFF
--- a/config/projects/private-chef.rb
+++ b/config/projects/private-chef.rb
@@ -1,6 +1,6 @@
 name "private-chef"
-maintainer "Opscode, Inc."
-homepage "http://www.opscode.com"
+maintainer "Chef Software, Inc."
+homepage   "http://www.getchef.com"
 
 replaces        "private-chef-full"
 install_dir    "/opt/opscode"


### PR DESCRIPTION
This data is important when publishing to Artifactory as it’s used in 
the underlying package path in the repo (e.g. `com/getchef`).

/cc @opscode/release-engineers @opscode/server-team 

We'll probably need to backport this change to all stable branches also.
