### PR TITLE
Dt/remove system recovery focus

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-default_version "dt/remove_focus"
+default_version "1.0.48"
 
 dependency "ruby"
 dependency "bundler"


### PR DESCRIPTION
Remove a :focus on system_recovery spec that slipped through; the pedant repo has the fix, this just bumps the tag in omnibus.
