### PR TITLE
enable actions by default

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -432,7 +432,7 @@ default['private_chef']['dark_launch']["private-chef"] = true
 default['private_chef']['dark_launch']["sql_users"] = true
 default['private_chef']['dark_launch']["add_type_and_bag_to_items"] = true
 default['private_chef']['dark_launch']["reporting"] = true
-default['private_chef']['dark_launch']["actions"] = false
+default['private_chef']['dark_launch']["actions"] = true
 
 ###
 # Opscode Account

--- a/files/private-chef-cookbooks/private-chef/recipes/actions.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/actions.rb
@@ -13,7 +13,7 @@ if is_data_master?
     owner node["private_chef"]["user"]["username"]
     group "root"
     mode "0600"
-    content ::File.open('/etc/opscode/webui_priv.pem')
+    content lazy {::File.open('/etc/opscode/webui_priv.pem').read}
   end
 
   file "/etc/opscode-analytics/actions-source.json" do


### PR DESCRIPTION
We should enable actions by default in Chef12.  If there is no actions consumer the messages just get dropped by RabbitMQ and no disk resources are used up
