### PR TITLE
Add option to set threads for cookbook uploads during upgrade

### DIFF
--- a/files/private-chef-ctl-commands/osc_upgrade.rb
+++ b/files/private-chef-ctl-commands/osc_upgrade.rb
@@ -350,9 +350,9 @@ def run_osc_upgrade
     # --skip-useracl skip importing user acls, which will just give the user's default acls. This is the
     # desired state anyway
     # --with-user-sql pull data across from the database, so we can get passwords
-    # --concurrency 1 so that it doesn't try concurrent cookbook uploads; there appears to be a bug
-    # around concurrent uploads
-    cmd = "/opt/opscode/embedded/bin/knife ec restore --skip-useracl --with-user-sql --concurrency 1 -c /tmp/knife-ec-backup-config.rb #{ec_data_dir}"
+    # --concurrency sets the number of threads to use for concurrent cookbook uploads. Default to 10, but the user can adjust if they desire.
+
+    cmd = "/opt/opscode/embedded/bin/knife ec restore --skip-useracl --with-user-sql --concurrency #{@options.upload_threads} -c /tmp/knife-ec-backup-config.rb #{ec_data_dir}"
     #cmd = "/opt/opscode/embedded/bin/knife ec restore --skip-useracl --concurrency 1 -c /tmp/knife-ec-backup-config.rb #{ec_data_dir}"
     #cmd = "/opt/opscode/embedded/bin/knife ec restore --skip-useracl --with-user-sql --concurrency 1 -c /tmp/knife-ec-backup-config.rb -VV #{ec_data_dir}"
     status = run_command(cmd)

--- a/files/private-chef-ctl-commands/upgrade.rb
+++ b/files/private-chef-ctl-commands/upgrade.rb
@@ -17,6 +17,7 @@ add_command "upgrade", "Upgrade your private chef installation.", 2 do
     # Define defaults
     @options.skip_confirmation = false
     @options.chef_server_url = "https://localhost"
+    @options.upload_threads = 10
 
     opt_parser = OptionParser.new do |opts|
       opts.on("-y", "--yes", "Skip confirmation") do |y|
@@ -34,6 +35,10 @@ add_command "upgrade", "Upgrade your private chef installation.", 2 do
       # Should this be chef-server-host to match sql-host?
       opts.on("--chef-server-url [url]", String, "The url of the chef server.  Defaults to #{@options.chef_server_url}") do |u|
          @options.chef_server_url = u
+      end
+
+      opts.on("--upload-threads [number]", Integer, "The number of threads to use when migrating cookbooks to the new server. Defaults to #{@options.upload_threads}") do |n|
+        @options.upload_threads = n
       end
 
       # TODO(jmink) Make this work without the '--'


### PR DESCRIPTION
Also make the default 10 from 1.

Otherwise upgrades are going to take a long time waiting on cookbooks to be migrated. We might consider bumping the default even higher, but for now it's set conservatively.
