### PR TITLE
Add coverband support to opscode-account

### DIFF
--- a/config/software/opscode-account.rb
+++ b/config/software/opscode-account.rb
@@ -1,5 +1,5 @@
 name "opscode-account"
-default_version "rel-1.49.0"
+default_version "rel-1.50.0"
 
 dependency "ruby"
 dependency "bundler"

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -463,6 +463,7 @@ default['private_chef']['opscode-account']['worker_timeout'] = 3600
 default['private_chef']['opscode-account']['validation_client_name'] = "chef"
 default['private_chef']['opscode-account']['umask'] = "0022"
 default['private_chef']['opscode-account']['worker_processes'] = node['cpu']['total'].to_i
+default['private_chef']['opscode-account']['enable_code_coverage'] = false
 
 ###
 # Chef Mover

--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-account.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-account.rb
@@ -26,7 +26,7 @@ end
 rebuild_config = File.join(private_chef_account_etc_dir, "rebuild.conf.rb")
 env_config = File.join(private_chef_account_etc_dir, "#{node['private_chef']['opscode-account']['environment']}.rb")
 statsd_config = File.join(private_chef_account_etc_dir, "statsd_config.rb")
-
+coverband_config = File.join(private_chef_account_etc_dir, "coverband.rb")
 
 template rebuild_config do
   source "rebuild.conf.rb.erb"
@@ -60,6 +60,18 @@ end
 
 link "/opt/opscode/embedded/service/opscode-account/statsd_config.rb" do
   to statsd_config
+end
+
+template coverband_config do
+  source "account_coverband_config.rb.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+  notifies :restart, 'runit_service[opscode-account]' unless backend_secondary?
+end
+
+link "/opt/opscode/embedded/service/opscode-account/config/coverband.rb" do
+  to coverband_config
 end
 
 unicorn_config File.join(private_chef_account_etc_dir, "unicorn.rb") do

--- a/files/private-chef-cookbooks/private-chef/templates/default/account_coverband_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/account_coverband_config.rb.erb
@@ -1,0 +1,7 @@
+Coverband.configure do |config|
+  config.root       = "/opt/opscode/embedded/service/opscode-account"
+  config.redis      = Redis.new({:host => "<%= node['private_chef']['redis_lb']['vip'] %>",
+                                 :port => <%= node['private_chef']['redis_lb']['port'] %>,
+                                 :db => '2'})
+  config.percentage = 100.0
+end

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-account-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-account-run.erb
@@ -4,4 +4,4 @@
 
 exec 2>&1
 cd /opt/opscode/embedded/service/opscode-account
-exec chpst -P -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> env HOME="<%= node['private_chef']['opscode-account']['dir'] %>" PATH=/opt/opscode/embedded/bin:$PATH bundle exec unicorn -E <%= node['private_chef']['opscode-account']['environment'] %> -c <%= File.join(node['private_chef']['opscode-account']['dir'], 'etc', 'unicorn.rb') %> /opt/opscode/embedded/service/opscode-account/config.ru
+exec chpst -P -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> env HOME="<%= node['private_chef']['opscode-account']['dir'] %>" <%= node['private_chef']['opscode-account']['enable_code_coverage'] ? "COVERBAND=true" : nil %> PATH=/opt/opscode/embedded/bin:$PATH bundle exec unicorn -E <%= node['private_chef']['opscode-account']['environment'] %> -c <%= File.join(node['private_chef']['opscode-account']['dir'], 'etc', 'unicorn.rb') %> /opt/opscode/embedded/service/opscode-account/config.ru


### PR DESCRIPTION
These are the configuration files needed to enable code coverage reports in opscode-account.

In /etc/opscode/private-chef.rb add:

```
opscode_account['enable_code_coverage'] = true
```

And then `private-chef-ctl reconfigure`.

/cc @marcparadise @opscode/server-team 
