### PR TITLE
Fix for upgrades the bad rabbit wait script.

### DIFF
--- a/files/private-chef-ctl-commands/osc_upgrade.rb
+++ b/files/private-chef-ctl-commands/osc_upgrade.rb
@@ -166,8 +166,9 @@ def run_osc_upgrade
     # This sed command was written to be as portable as possible and to leave no
     # tmp file behind. See:
     # https://stackoverflow.com/questions/5171901/sed-command-find-and-replace-in-file-and-overwrite-file-doesnt-work-it-empties
+    # The copy is done to ensure we keep the permissions of the original file
     script = "/opt/chef-server/bin/wait-for-rabbit"
-    sed = "sed 's/opscode/chef-server/g' #{script} > #{script}.tmp && mv #{script}.tmp #{script}"
+    sed = "sed 's/opscode/chef-server/g' #{script} > #{script}.tmp && cp --no-preserve=mode,ownership #{script}.tmp #{script} && rm #{script}.tmp"
     msg = "Failed to write fix to wait-for-rabbit script"
     check_status(run_command(sed), msg)
   end


### PR DESCRIPTION
The script was checked in with a copy-paste error into OSC
where it checks that EC rabbit is running. This wasn't noticed
before b/c it has a bail option where it does nothing if EC isn't on the
box. EC was of course never on an OSC box, until now.

This fix just makes the script a blank file, so upgrades can progress
and be rerun as needed. Further details are in a comment in the code.

I believe this works, but hit a redis issue locally that I need to fully work out to finish testing. Wanted to get the PR out though.
