### PR TITLE
OC-11710 - Fix couchdb compaction log rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### private-chef-cookbooks
 * [OC-11673] Tune PostgreSQL keepalive timeouts
 * [OC-11668] enable ipv6 in standalone mode
+* [OC-11710] Fix couchdb compaction log rotation
 
 ### private-chef-ctl
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ The following items are the set of bug fixes that have been applied since Enterp
 * [OC-11575][enterprise-chef-common] Don't start services by default in HA topology
 * [OC-11601] - Correct another case where redis_lb was not started before attempting to reconfigure it
 * [OC-11672] Upgrade PostgreSQL to 9.2.9
+* [OC-11710] Fix couchdb compaction log rotation
 
 
 ## 11.1.8 (2014-06-26)

--- a/files/private-chef-cookbooks/private-chef/recipes/couchdb.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/couchdb.rb
@@ -63,8 +63,8 @@ end
 
 # Add it to cron
 cron_email = node['private_chef']['notification_email']
-cron_cmd = "#{compact_script_command} 2>&1 > #{couchdb_log_dir}/compact-`date \"+\\%Y\\%m\\%d\\%H\\%M\\%S\"`.log"
-cron_cmd_major_offenders = "#{compact_script_command} --max-dbs=50 2>&1 > #{couchdb_log_dir}/compact-`date \"+\\%Y\\%m\\%d\\%H\\%M\\%S\"`.log"
+cron_cmd = "#{compact_script_command} 2>&1 >> #{couchdb_log_dir}/compact.log"
+cron_cmd_major_offenders = "#{compact_script_command} --max-dbs=50 2>&1 >> #{couchdb_log_dir}/compact.log"
 
 template "/etc/cron.d/couchdb_compact" do
   source "compact-cron-entry.erb"
@@ -107,5 +107,7 @@ template "/etc/opscode/logrotate.d/couchdb" do
   owner "root"
   group "root"
   mode "0644"
-  variables(node['private_chef']['couchdb'].to_hash)
+  variables(node['private_chef']['couchdb'].to_hash.merge(
+    'copytruncate' => true
+  ))
 end


### PR DESCRIPTION
Each couchdb compaction run output goes to a new file so they never get
large enough for logrotate to rotate or remove them causing the number of
compaction log files grows without bound.

Solution: have compaction script output to compaction.log and logrotate handles the rest.

Also, we need to use 'copytruncate' since logrotate wants to compress the
file and we don't know if the compaction script still has it open.
