### PR TITLE
Xdl for org / assoc / invite endpoints. Delete redundant routing code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 12.0.0 (Unreleased)
 
+### oc-chef-pedant 1.0.53
+* Remove /system-recovery endpoint tests
+
 ### postgresql 2014.07.29
 * [OC-11672] Upgrade PostgreSQL to 9.2.9
 

--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-default_version "1.0.52"
+default_version "1.0.53"
 
 dependency "ruby"
 dependency "bundler"

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -260,6 +260,9 @@ default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = true
+default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = true
+default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = true
+default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = true
 
 ####
 # Nginx

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
@@ -22,6 +22,15 @@ local function Cendpoint(exp)
   return Cg(exp, "endpoint")
 end
 
+-- match the first argument and set the endpoint to the second argument.
+-- useful for when you want to set a route to an endpoint whose name
+-- is not contained in the route.
+-- for example:
+--   Cmatch_and_assign_endpoint(p_users, "associations") * p_sep * p_eol
+-- would match /users(/) and set its endpoint to "associations"
+local function Cmatch_and_assign_endpoint(p_to_match, endpoint_string)
+   return p_to_match * Cendpoint(Cc(endpoint_string))
+end
 
 -- Basic identifiers
 local p_eol = P(-1)
@@ -35,7 +44,6 @@ local p_dot = P"."
 -- Route Components
 local p_org = P"organizations"
 local p_org_base = P"/organizations"
-local p_verify_password = P"verify_password"
 local p_auth_user = P"authenticate_user"
 local p_system_recovery = P"system_recovery"
 local p_license = P"license"
@@ -54,6 +62,7 @@ local p_association_requests = P"association_requests"
 local p_clients = P"clients"
 local p_runs = P"runs"
 local p_principals = P"principals"
+local p_internal_organizations_base = P"/internal-organizations"
 
 -- Composite patterns
 local p_maybe_sep = p_sep^-1
@@ -93,7 +102,7 @@ local c_maybe_identifier = (p_sep * c_identifier)^-1
 
 local p_erchef_endpoint = p_cookbooks + p_data + p_roles + p_sandboxes +
                           p_environments + p_clients + p_nodes + p_principals +
-			   p_groups + p_containers
+                          p_groups + p_containers
 
 -- endpoints that map directly to erchef
 -- If an object identifier is present - as identified with /IDENTIFIER - then
@@ -123,33 +132,47 @@ local p_erchef_int = p_erchef +
 
 -- /users endpoints for account:
 local p_named_user = (p_sep * p_users * p_sep * c_identifier)
-local p_acct_users = (p_named_org_prefix * Cendpoint(p_users) * (p_sep + p_eol)) +
-                     (p_sep * Cendpoint(p_users) * (p_sep * c_identifier)^-1 * p_trailing_sep) +
-                      p_named_user *
-                          -- below rule for backwards compatibility with original:
-                          -- /users/BLAH/{0,1}/association_requests
-                          -- which permits: /users/BLAH//association_requests
-                          ( (p_sep * p_maybe_sep * Cendpoint(p_association_requests) * (p_sep + p_eol)) +
-                            (p_sep * Cendpoint(p_org) * p_trailing_sep) )
+
+
+                     -- /organizations/:orgname/association_requests(/), custom endpoint for darklaunch
+local p_acct_users = (p_named_org_prefix * Cendpoint(p_association_requests) * (p_sep + p_eol)) +
+                     -- /organizations/:orgname/users/:username(/), endpoint "associations" for darklaunch
+                     (p_named_org_prefix * Cmatch_and_assign_endpoint(p_users, "associations") * p_sep * c_identifier * (p_sep + p_eol)) +
+                     -- /organizations/:orgname/users(/)
+                     (p_named_org_prefix * Cmatch_and_assign_endpoint(p_users, "associations") * (p_sep + p_eol)) +
+                     -- /users/:username/(/)association_requets(/) OR /users/:username/organiztaions(/)
+                     p_named_user *
+                       -- below rule for backwards compatibility with original:
+                       -- /users/BLAH/{0,1}/association_requests
+                       -- which permits: /users/BLAH//association_requests
+                       ((p_sep * p_maybe_sep * Cendpoint(p_association_requests) * (p_sep + p_eol)) +
+                       -- set /users/:username/organiztaions(/) to endpoint "associations" so we
+                       -- can darklaunch it
+                       (p_sep * Cmatch_and_assign_endpoint(p_org, "associations") * p_trailing_sep) )
+
+
+-- /organizations(/:orgname/)
+local p_org_endpoint = (p_sep * Cendpoint(p_org) * (p_sep * Cg(p_org_identifier, "org_name"))^-1 * p_trailing_sep)
+
 -- account endpoints
 -- note that the acl endpoint is a special case because it supercedes all others
 -- including routes that would otherwise go to erchef.
 local p_acl_endpoint = (p_named_org_prefix * p_all_until_acl * Cendpoint(p_acl) * (p_sep + p_eol)) +
                        (p_named_user * Cendpoint(p_acl) * (p_sep + p_eol))
-local p_acct_direct = Cendpoint(p_users + p_association_requests) * (p_sep + p_eol)
-local p_acct = (p_named_org_prefix * p_acct_direct) +
-               (p_sep * Cendpoint(p_org) * (p_sep * Cg(p_org_identifier, "org_name"))^-1 * p_trailing_sep) +
-               (p_sep * Cendpoint(p_verify_password + p_system_recovery) * p_trailing_sep) +
-               p_acct_users
+
+local p_acct = (p_sep * Cendpoint(p_system_recovery) * p_trailing_sep)
 
 -- Default org endpoints. This is to help with migrating from OSC 11 to Chef Server 12
-local p_default_org_endpoints = p_search + p_nodes + p_cookbooks + p_data + p_roles + p_sandboxes + p_environments + p_clients +p_runs + p_principals + p_groups + p_containers
+local p_default_org_endpoints = p_search + p_nodes + p_cookbooks + p_data + p_roles + p_sandboxes + p_environments + p_clients + p_runs + p_principals + p_groups + p_containers
+
+-- acct_erchef endpoints that are also routed to internal_acct
+local p_internal_acct_erchef_endpoints = p_acct_users + p_org_endpoint
 
 local uri_resolvers = {
   -- Retain ordering to ensure proper eval:
-  -- p_acl_endpont must come firs tbecause a trailing _acl takes precedence
+  -- p_acl_endpont must come first because a trailing _acl takes precedence
   -- over any other identifiers which may be in the url.
-  api = (p_acl_endpoint * c_acct_erchef) +
+  api = ((p_acl_endpoint + p_internal_acct_erchef_endpoints) * c_acct_erchef) +
         (p_erchef * c_erchef) +
         (p_acct * c_acct),
 
@@ -167,8 +190,8 @@ local uri_resolvers = {
                   -- until we either correct or retire webui 1
                   ((p_named_org_prefix * Cendpoint(p_clients) * c_maybe_identifier) * c_erchef) +
                   (p_erchef_users * c_erchef) +
-                  ((p_acct +
-                   (p_named_org + p_sep)) * c_acct),
+                  (p_internal_acct_erchef_endpoints * c_acct_erchef) +
+                  ((p_acct + p_internal_organizations_base) * c_acct),
 
   -- Anything that routes to erchef or reporting is handled here.
   internal_chef = (p_erchef_int * c_erchef)

--- a/tests/routing/routes_test.lua
+++ b/tests/routing/routes_test.lua
@@ -18,16 +18,23 @@ local int_acct_tests = endpoint_tests.internal_acct
 local int_chef_tests = endpoint_tests.internal_chef
 
 -- accounts via organization
-table.insert(shared_acct_tests, {"/organizations",                            { DEF_ORG, "acct", "organizations" }})
-table.insert(shared_acct_tests, {"/organizations/",                           { DEF_ORG, "acct", "organizations" }})
-table.insert(shared_acct_tests, {"/organizations/testorg",                    { TEST_ORG, "acct", "organizations" }})
-table.insert(shared_acct_tests, {"/organizations/testorg/",                   { TEST_ORG, "acct", "organizations" }})
+table.insert(shared_acct_tests, {"/organizations",                            { DEF_ORG, "acct_erchef", "organizations" }})
+table.insert(shared_acct_tests, {"/organizations/",                           { DEF_ORG, "acct_erchef", "organizations" }})
+table.insert(shared_acct_tests, {"/organizations/testorg",                    { TEST_ORG, "acct_erchef", "organizations" }})
+table.insert(shared_acct_tests, {"/organizations/testorg/",                   { TEST_ORG, "acct_erchef", "organizations" }})
 
-for _k, val in pairs{"users", "association_requests"} do
-table.insert(shared_acct_tests, {"/organizations/testorg/" .. val,            { TEST_ORG, "acct", val, nil}})
-table.insert(shared_acct_tests, {"/organizations/testorg/" .. val .. "/",     { TEST_ORG, "acct", val, nil}})
-table.insert(shared_acct_tests, {"/organizations/testorg/" .. val .."/any",   { TEST_ORG, "acct", val, nil}})
+for _k, val in pairs{"users"} do
+table.insert(shared_acct_tests, {"/organizations/testorg/" .. val,            { TEST_ORG, "acct_erchef", "associations", nil}})
+table.insert(shared_acct_tests, {"/organizations/testorg/" .. val .. "/",     { TEST_ORG, "acct_erchef", "associations", nil}})
 end
+
+for _k, val in pairs{"association_requests"} do
+table.insert(shared_acct_tests, {"/organizations/testorg/" .. val,            { TEST_ORG, "acct_erchef", val, nil}})
+table.insert(shared_acct_tests, {"/organizations/testorg/" .. val .. "/",     { TEST_ORG, "acct_erchef", val, nil}})
+end
+
+table.insert(shared_acct_tests, {"/organizations/testorg/users/any",   { TEST_ORG, "acct_erchef", "associations", "any"}})
+table.insert(shared_acct_tests, {"/users/any/organizations",   { nil, "acct_erchef", "associations", "any"}})
 
 -- note that the actual endpoint is "/_acl" with support for /_acl/create|update|delete|grant - however our original expression specified
 -- our original endpoint accepted "/_acl.*"; we have made it slightly more strict in that it must be
@@ -38,8 +45,9 @@ table.insert(shared_acct_tests, {"/organizations/testorg/nodes/mynode/_acl/",  {
 table.insert(shared_acct_tests, {"/organizations/testorg/nodes/mynode/_acl/test",  { TEST_ORG, "acct_erchef", "acls"}})
 table.insert(shared_acct_tests, {"/organizations/testorg/nodes/_acl",         { TEST_ORG, "acct_erchef", "acls"}})
 table.insert(shared_acct_tests, {"/organizations/testorg/roles/_acl",         { TEST_ORG, "acct_erchef", "acls"}})
--- This goes to account not because _aclextra is valid, but because EVERYTHING is accepted into account for acct internal
-table.insert(int_acct_tests, {"/organizations/testorg/nodes/mynode/_aclextra",  { TEST_ORG, "acct", nil}})
+
+-- Verify that _aclextra is not being routed to _acl; it should simply not be routed as it is not valid.
+table.insert(int_acct_tests, {"/organizations/testorg/nodes/mynode/_aclextra",  { DEF_ORG, nil, nil}})
 -- _aclextra isn't valid, so the correct erchef route should take priority.
 table.insert(api_tests, {"/organizations/testorg/nodes/mynode/_aclextra",  { TEST_ORG, "erchef", "nodes", "mynode"}})
 
@@ -48,21 +56,20 @@ table.insert(shared_chef_tests, {"/users",                                    {D
 table.insert(shared_chef_tests, {"/users/",                                   {DEF_ORG, "erchef", "users"}})
 table.insert(shared_chef_tests, {"/users/borg",                               {DEF_ORG, "erchef", "users", "borg"}})
 table.insert(shared_chef_tests, {"/users/borg/",                              {DEF_ORG, "erchef", "users", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg/association_requests",          {DEF_ORG, "acct", "association_requests", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg/association_requests/",         {DEF_ORG, "acct", "association_requests", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg/association_requests/abc",      {DEF_ORG, "acct", "association_requests", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg//association_requests",         {DEF_ORG, "acct", "association_requests", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg//association_requests/",        {DEF_ORG, "acct", "association_requests", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg//association_requests/abc",     {DEF_ORG, "acct", "association_requests", "borg"}})
-table.insert(shared_acct_tests, {"/users/borg/organizations",                 {DEF_ORG, "acct", "organizations", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg/association_requests",          {DEF_ORG, "acct_erchef", "association_requests", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg/association_requests/",         {DEF_ORG, "acct_erchef", "association_requests", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg/association_requests/abc",      {DEF_ORG, "acct_erchef", "association_requests", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg//association_requests",         {DEF_ORG, "acct_erchef", "association_requests", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg//association_requests/",        {DEF_ORG, "acct_erchef", "association_requests", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg//association_requests/abc",     {DEF_ORG, "acct_erchef", "association_requests", "borg"}})
+table.insert(shared_acct_tests, {"/users/borg/organizations",                 {DEF_ORG, "acct_erchef", "associations", "borg"}})
 
--- Different behavior between int-acct and api here, because int-acct will take anything
--- while api requires a valid destiniation. This differs slightly from original behavior, in
--- which api accepted association_requests + 'anythign' without a separator in between
-table.insert(api_tests, {"/users/borg//association_requests0abc",     {nil} })
-table.insert(api_tests, {"/users/borg/association_requests0abc",      {nil} })
-table.insert(int_acct_tests, {"/users/borg//association_requests0abc",     {nil, "acct"} })
-table.insert(int_acct_tests, {"/users/borg/association_requests0abc",      {nil, "acct"}})
+-- Verify that association_requests + junk is not being improperly routed to association_requests
+-- endpoint or account. Its invalid and should not route anywhere at all.
+table.insert(api_tests, {"/users/borg//association_requests0abc", {nil} })
+table.insert(api_tests, {"/users/borg/association_requests0abc",  {nil} })
+table.insert(int_acct_tests, {"/users/borg//association_requests0abc", {nil, nil} })
+table.insert(int_acct_tests, {"/users/borg/association_requests0abc",  {nil, nil}})
 
 -- other accounts
 table.insert(shared_chef_tests, {"/authenticate_user",  {DEF_ORG, "erchef", "authenticate_user"}})
@@ -81,6 +88,12 @@ table.insert(int_acct_tests, {"/organizations/testorg/" .. val .. "/",    {TEST_
 table.insert(int_acct_tests, {"/organizations/testorg/" .. val .. "/abc", {TEST_ORG, "erchef", val, "abc"}})
 table.insert(int_acct_tests, {"/organizations/testorg/" .. val .. "/_acl", {TEST_ORG, "acct_erchef", "acls"}})
 end
+
+-- Verify that /organizations endpoint is properly routed internally
+table.insert(int_acct_tests, {"/organizations",          {DEF_ORG, "acct_erchef", "organizations"}})
+table.insert(int_acct_tests, {"/organizations/",         {DEF_ORG, "acct_erchef", "organizations"}})
+table.insert(int_acct_tests, {"/organizations/testorg",  {TEST_ORG, "acct_erchef", "organizations"}})
+table.insert(int_acct_tests, {"/organizations/testorg/", {TEST_ORG, "acct_erchef", "organizations"}})
 
 -- darklaunch account or erchef
 -- (none at this time, in Migration Phase 3 we'll have some)
@@ -130,8 +143,11 @@ table.insert(shared_chef_tests, {"/organizations/testorg/nodesabc", {nil}})
 -- However these should return  both the org name and the correct upstream (but still no known endpoint),
 table.insert(api_tests, {"/organizations/testorg/association_requestsdef",  {nil}})
 
--- since internal acct accepts everything and should parse what it can
-table.insert(int_acct_tests, {"/organizations/testorg/association_requestsdef",  {TEST_ORG, "acct"}})
+-- This route is invalid in general and should also not be routed internally to anything.
+table.insert(int_acct_tests, {"/organizations/testorg/association_requestsdef",  {DEF_ORG, nil}})
+
+-- Verify that root "/" doesn't go anywhere, it is an invalid route.
+table.insert(int_acct_tests, {"/",  {nil, nil}})
 
 -- Bad matches should never return a route:
 table.insert(shared_chef_tests, {"/organizations/testorg/nOdes/abc/",         {nil}})
@@ -177,16 +193,18 @@ for k,v in pairs(shared_acct_tests) do
   table.insert(int_acct_tests, k, v)
 end
 
--- For internal acct , we accept pretty much everything and route it along - only thing
--- we're really conerned with here is capturing org name and endpoint names.
--- Let's just make sure w're not picking up org name when we shouldn't...
-table.insert(int_acct_tests, {"/organizations/TestOrg",                    {DEF_ORG, "acct"}})
-table.insert(int_acct_tests, {"/organizations/TestOrg/",                   {DEF_ORG, "acct"}})
-table.insert(int_acct_tests, {"/organizations/TestOrg/abc",                {DEF_ORG, "acct"}})
+-- Org names that do not match our requirements should not route be routed anywhere,
+-- in this case, there are capital letters which are illegal.
+-- Also note that the "matched org" should be the default_org since TestOrg should not get picked
+-- up as an org.
+table.insert(int_acct_tests, {"/organizations/TestOrg",                    {DEF_ORG, nil}})
+table.insert(int_acct_tests, {"/organizations/TestOrg/",                   {DEF_ORG, nil}})
+table.insert(int_acct_tests, {"/organizations/TestOrg/abc",                {DEF_ORG, nil}})
 
--- And make sure that these get consumed correctly:
-table.insert(int_acct_tests, {"/organization",                             {DEF_ORG, "acct"}})
-table.insert(int_acct_tests, {"/internal-organization",                    {DEF_ORG, "acct"}})
+-- /organization is not a valid route and shouldn't route anywhere
+table.insert(int_acct_tests, {"/organization", {DEF_ORG, nil}})
+
+table.insert(int_acct_tests, {"/internal-organizations", {DEF_ORG, "acct"}})
 
 version_tests = {}
 table.insert(version_tests, {"10.0.0",  true})


### PR DESCRIPTION
This code makes the following endpoints darklaunchable for whether they are routed to erchef or opscode-account:
- orgs (xdl flag `couchdb_organizations`):
  - /organizations
  - /organizations/orgname
- org associations (xdl flag `couchdb_associations`):
  - /organizations/orgname/users/username
  - /users/username/organizations
- org invites (xdl flag `couchdb_association_requests`):
  - /organizations/orgname/association_requests
  - /users/username/association_requests

Also contains a bit of cleanup and elimination of redundancies in the routing code.

[CI Build](http://wilson.ci.opscode.us/job/private-chef-trigger-ad_hoc/175/downstreambuildview/)
