### PR TITLE
[OC-11540] Fix invalid opscode-account config when forcing SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [OC-11673] Tune PostgreSQL keepalive timeouts
 * [OC-11668] enable ipv6 in standalone mode
 * [OC-11710] Fix couchdb compaction log rotation
+* [OC-11540] Fix invalid opscode-account config when forcing SSL
 
 ### private-chef-ctl
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ The following items are the set of bug fixes that have been applied since Enterp
 * [OC-11710] Fix couchdb compaction log rotation
 * [OC-11702] Fix bug that prevents ACL and group expansion when containing group that no longer exists
 * [OC-11708] Fix user association bug when last updater of users group is no longer associated
+* [OC-11540] Fix invalid opscode-account config when forcing SSL
 
 
 ## 11.1.8 (2014-06-26)

--- a/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -162,6 +162,15 @@ EOKEY
   def erl_atom_or_string(term)
     self.class.erl_atom_or_string(term)
   end
+
+  # OC-11540, fallback to ssl_port if non_ssl_port is disabled
+  def internal_lb_url
+    if node['private_chef']['nginx']['non_ssl_port'] == false
+      "https://#{vip_for_uri('lb_internal')}:#{node['private_chef']['nginx']['ssl_port']}"
+    else
+      "http://#{vip_for_uri('lb_internal')}:#{node['private_chef']['nginx']['non_ssl_port']}"
+    end
+  end
 end
 
 class Chef::Resource::Template

--- a/files/private-chef-cookbooks/private-chef/templates/default/opscode-account-config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/opscode-account-config.rb.erb
@@ -1,7 +1,7 @@
 Chef::Config[:chargify_api_secret] = ''
 Chef::Config[:chargify_site]       = 'opscode-preprod'
 
-Chef::Config[:internal_lb_url] = 'http://<%=@helper.vip_for_uri('lb_internal') %>:<%=node['private_chef']['nginx']['non_ssl_port']%>'
+Chef::Config[:internal_lb_url] = '<%=@helper.internal_lb_url%>'
 Chef::Config[:dark_launch_config_filename] = '/etc/opscode/dark_launch_features.json'
 Chef::Config[:account_service_uri]   = 'http://<%= @helper.vip_for_uri('lb_internal') %>:<%= node['private_chef']['lb_internal']['account_port'] %>'
 Chef::Config[:chef_server_host_uri]  = 'http://<%= @helper.vip_for_uri('lb_internal') %>:<%= node['private_chef']['lb_internal']['chef_port'] %>'


### PR DESCRIPTION
This is an 11.1-stable rebase of #288,  which was merged into master but never made it into 11.1.6.
