### PR TITLE
add webui deprecation notice

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/opscode_webui_deprecation_notice.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/opscode_webui_deprecation_notice.rb
@@ -1,0 +1,32 @@
+
+class OpscodeWebuiDeprecationNotice
+  attr_reader :opscode_webui_attribute_keys
+
+  def initialize(opscode_webui_attributes)
+    @opscode_webui_attribute_keys = (opscode_webui_attributes || {}).keys
+  end
+
+  def applicable?
+    @applicable ||= !opscode_webui_attribute_keys.empty?
+  end
+
+  def message
+    <<-EOS
+
+
+    Your configuration file contains the following deprecated settings:
+
+    #{formatted_attributes_for_message}
+
+    These settings will have no effect and should be removed.
+    EOS
+  end
+
+  private
+
+  def formatted_attributes_for_message
+    @formatted_attributes_for_message ||= opscode_webui_attribute_keys.map do |key|
+      "  opscode_webui['#{key}']"
+    end.join('\n')
+  end
+end

--- a/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -58,6 +58,16 @@ else
   node.consume_attributes(PrivateChef.generate_config(node['fqdn']))
 end
 
+# Warn about deprecated opscode_webui settings
+opscode_webui_deprecation_notice = OpscodeWebuiDeprecationNotice.new(
+  PrivateChef['opscode_webui']
+)
+log 'opscode_webui deprecation notice' do
+  message opscode_webui_deprecation_notice.message
+  level :warn
+  only_if { opscode_webui_deprecation_notice.applicable? }
+end
+
 # @todo: This seems like it might belong in the PrivateChef helper;
 #   many other attributes like are set automatically there as well.
 if OmnibusHelper.has_been_bootstrapped?

--- a/files/private-chef-cookbooks/private-chef/spec/libraries/opscode_webui_deprecation_notice_spec.rb
+++ b/files/private-chef-cookbooks/private-chef/spec/libraries/opscode_webui_deprecation_notice_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../libraries/opscode_webui_deprecation_notice'
+
+describe OpscodeWebuiDeprecationNotice do
+  subject(:opscode_webui_deprecation_notice) { described_class.new(attributes) }
+
+  describe '#applicable?' do
+    subject(:applicable?) { opscode_webui_deprecation_notice.applicable? }
+
+    context 'when opscode_webui attributes are set' do
+      let(:attributes) { { 'test' => 123 } }
+
+      it 'is true' do
+        expect(applicable?).to eq true
+      end
+    end
+
+    context 'when opscode_webui attributes are not set' do
+      let(:attributes) { {} }
+
+      it 'is false' do
+        expect(applicable?).to eq false
+      end
+    end
+  end
+
+  describe '#message' do
+    let(:attributes) { { 'abc' => '123', 'def' => '456' } }
+
+    it 'shows the attributes' do
+      expect(opscode_webui_deprecation_notice.message).to include('abc', 'def')
+    end
+  end
+end


### PR DESCRIPTION
Logs a message if any `opscode_webui['things']` are in /etc/opscode/private-chef.rb.
