### PR TITLE
Remove upgrade sleeps

### DIFF
--- a/files/private-chef-ctl-commands/osc_upgrade.rb
+++ b/files/private-chef-ctl-commands/osc_upgrade.rb
@@ -152,22 +152,6 @@ def run_osc_upgrade
     check_status(run_command(sed), msg)
   end
 
-  def wait_for_ready_server(server_version)
-    1.upto(120) do |count|
-      begin
-        server_status = JSON.parse(open('http://localhost:8000/_status').read)
-        fail unless server_status['status'] == 'pong'
-      # Catch exceptions because if the server isn't yet up trying to open the status endpoint throws one
-      rescue Exception => e
-        sleep 1
-        if count == 120
-          log "Timeout waiting for #{server_version} server to start. Received expection #{e.message}"
-          exit 1
-        end
-      end
-    end
-  end
-
   def start_osc
     # Assumption is EC isn't running, since we detected OSC on the system
     log 'Ensuring the Open Source Chef server is started'


### PR DESCRIPTION
Instead of relying on sleeps when we need to ensure a Chef Server is fully running, check the status endpoint instead.

:hatched_chick: (I'd do a hat tip, but github doesn't seem to have that) to @irvingpop's comment here, which I used as a starting point to work out the current code. https://github.com/opscode/opscode-omnibus/pull/299

@opscode/server-team consider this open for review. 
