### PR TITLE
Ensure HA setup happens before service setup.

### DIFF
--- a/files/private-chef-cookbooks/ha/recipes/drbd.rb
+++ b/files/private-chef-cookbooks/ha/recipes/drbd.rb
@@ -89,6 +89,10 @@ service drbd start
   not_if { File.exists?(File.join(drbd_dir, "drbd_ready")) }
 end
 
+directory "#{node['private_chef']['keepalived']['dir']}/bin" do
+  recursive true
+end
+
 template "#{node['private_chef']['keepalived']['dir']}/bin/ha_backend_storage" do
   source "ha_backend_storage_drbd.erb"
   owner "root"

--- a/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -165,6 +165,7 @@ end
 
 include_recipe "enterprise::runit"
 include_recipe "private-chef::sysctl-updates"
+include_recipe "ha"
 
 # Configure Services
 [
@@ -219,8 +220,6 @@ include_recipe "private-chef::sysctl-updates"
 
   end
 end
-
-include_recipe "ha"
 
 include_recipe "private-chef::actions" if darklaunch_values["actions"]
 


### PR DESCRIPTION
If the HA setup doesn't happen first, your databases get bootstrapped
to the wrong place, and you will have a bad day.
