### PR TITLE
Slight overhaul of service handling to make upgrade faster.

### DIFF
--- a/files/private-chef-ctl-commands/upgrade.rb
+++ b/files/private-chef-ctl-commands/upgrade.rb
@@ -100,13 +100,17 @@ add_command "upgrade", "Upgrade your private chef installation.", 2 do
   def partybus_upgrade
     # Original Enterprise Chef upgrade path
     reconfigure(false)
-    # Put everything in a down state before we upgrade things.
+    # Put everything in a down state except postgres before we upgrade things.
     # How upgrades should handle services:
     #  + It should expect services to be down, but turn off services
     #    if its important that they be off for the upgrade.
     #  + It should start any services it needed, and turn them off
     #    at the end of a migration.
+    # with postgres being the exception to those rules. We are leaving
+    # postgres up atm to avoid having to constantly restart it.
     run_command("private-chef-ctl stop")
+    run_command("private-chef-ctl start postgresql")
+    sleep 15
     Dir.chdir(File.join(base_path, "embedded", "service", "partybus"))
     bundle = File.join(base_path, "embedded", "bin", "bundle")
     status = run_command("#{bundle} exec ./bin/partybus upgrade")

--- a/files/private-chef-upgrades/001/009_migrate_authz.rb
+++ b/files/private-chef-upgrades/001/009_migrate_authz.rb
@@ -5,8 +5,6 @@ define_upgrade do
   if Partybus.config.bootstrap_server
     must_be_data_master
 
-    start_service('postgresql')
-
     down_services = ['nginx',
                      'opscode-org-creator',
                      'bookshelf',
@@ -25,7 +23,6 @@ define_upgrade do
     migrate_script = "/opt/opscode/embedded/service/oc_authz_migrator/scripts/opc-run.sh"
     run_command("#{migrate_script} #{Partybus.config.couchdb_data_dir}/authorization.couch")
 
-    stop_service('postgresql')
   end
 
 end

--- a/files/private-chef-upgrades/001/010_chef_mover.rb
+++ b/files/private-chef-upgrades/001/010_chef_mover.rb
@@ -11,7 +11,7 @@ define_upgrade do
     # Only starting opscode-account and couchdb so that we can
     # delete pre-created orgs. Those two are stopped right after
     # pre-created orgs are deleted.
-    start_services(['postgresql', 'opscode-account', 'couchdb'])
+    start_services(['opscode-account', 'couchdb'])
 
     # Need to remove any existing pre-created orgs, since chef-mover
     # doesn't migrate them.  Otherwise, the next handful of orgs that
@@ -64,8 +64,6 @@ define_upgrade do
 
     # We don't need chef-mover anymore
     run_command("private-chef-ctl stop opscode-chef-mover")
-
-    stop_service('postgresql')
   end
 
 end

--- a/files/private-chef-upgrades/001/011_upgrade_cbv_schema.rb
+++ b/files/private-chef-upgrades/001/011_upgrade_cbv_schema.rb
@@ -1,6 +1,4 @@
 define_upgrade do
-  start_service('postgresql')
   upgrade_schema_to 33
-  stop_service('postgresql')
   restart_service "opscode-erchef"
 end

--- a/files/private-chef-upgrades/001/012_erchef_to_sqitch.rb
+++ b/files/private-chef-upgrades/001/012_erchef_to_sqitch.rb
@@ -4,8 +4,6 @@ define_upgrade do
 
     must_be_data_master
 
-    start_service('postgresql')
-
     sqitch = "sudo -u #{Partybus.config.database_unix_user} PATH=/opt/opscode/embedded/bin:/sbin:/usr/sbin:/bin:/usr/bin /opt/opscode/embedded/bin/sqitch"
 
     # This command ensures Sqitch has all the metadata for changes to
@@ -26,8 +24,6 @@ define_upgrade do
     # existing schema, so it is '--log-only'.
     run_command("#{sqitch} deploy --log-only --to-target @2.0.0",
                 :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema")
-
-    stop_service('postgresql')
 
   end
 end

--- a/files/private-chef-upgrades/001/013_bcrypt_users.rb
+++ b/files/private-chef-upgrades/001/013_bcrypt_users.rb
@@ -4,8 +4,6 @@ define_upgrade do
 
     must_be_data_master
 
-    start_service('postgresql')
-
     sqitch = "sudo -u #{Partybus.config.database_unix_user} PATH=/opt/opscode/embedded/bin:/sbin:/usr/sbin:/bin:/usr/bin /opt/opscode/embedded/bin/sqitch"
 
     # Dependent OSS schema
@@ -17,7 +15,5 @@ define_upgrade do
     # so we'll go ahead and upgrade thos as well.
     run_command("#{sqitch} deploy --to-target @2.2.3",
                 :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema")
-
-    stop_service('postgresql')
   end
 end

--- a/files/private-chef-upgrades/001/014_upgrade_migration_schema.rb
+++ b/files/private-chef-upgrades/001/014_upgrade_migration_schema.rb
@@ -4,15 +4,10 @@ define_upgrade do
 
     must_be_data_master
 
-    start_service('postgresql')
-
     # run 2.2.4 migration which includes schema upgrade for migration state
     run_command("make deploy",
                 :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema",
                 :env => {"EC_TARGET" => "@2.2.4", "OSC_TARGET" => "@1.0.4", "DB_USER" => "opscode-pgsql"}
                 )
-
-    stop_service('postgresql')
-
   end
 end

--- a/files/private-chef-upgrades/001/015_chef_mover_phase_2.rb
+++ b/files/private-chef-upgrades/001/015_chef_mover_phase_2.rb
@@ -9,8 +9,6 @@ define_upgrade do
     # Make sure API is down
     stop_services(["nginx", "opscode-erchef"])
 
-    start_service('postgresql')
-
     clean_mover_logs
 
     ####
@@ -26,8 +24,6 @@ define_upgrade do
                 "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate mover_phase_2_migration_callback normal")
 
     stop_service("opscode-chef-mover")
-
-    stop_service('postgresql')
 
     log "Containers and groups migration complete!"
   end

--- a/files/private-chef-upgrades/001/016_add_org_tables_osc_hash_types.rb
+++ b/files/private-chef-upgrades/001/016_add_org_tables_osc_hash_types.rb
@@ -4,8 +4,6 @@ define_upgrade do
 
     must_be_data_master
 
-    start_service('postgresql')
-
     # run 2.4.0 migrations to update db - includes adding org association/user tables
     # and adding the OSC password hash types to the password_hash_type_enum
     run_command("make deploy",
@@ -13,6 +11,5 @@ define_upgrade do
                 :env => {"EC_TARGET" => "@2.4.0", "OSC_TARGET" => "@1.0.4", "DB_USER" => "opscode-pgsql"}
                 )
 
-    stop_service('postgresql')
   end
 end

--- a/files/private-chef-upgrades/001/017_global_containers_migration.rb
+++ b/files/private-chef-upgrades/001/017_global_containers_migration.rb
@@ -6,8 +6,6 @@ define_upgrade do
     # Make sure API is down
     stop_services(["nginx", "opscode-erchef"])
 
-    start_service("postgresql")
-
     # migrate global containers
     force_restart_service("opscode-chef-mover")
 
@@ -17,7 +15,5 @@ define_upgrade do
                 "mover_global_containers_migration_callback normal mover_transient_queue_batch_migrator")
 
     stop_service("opscode-chef-mover")
-
-    stop_service('postgresql')
   end
 end

--- a/files/private-chef-upgrades/001/018_reindex_migration.rb
+++ b/files/private-chef-upgrades/001/018_reindex_migration.rb
@@ -6,7 +6,7 @@ define_upgrade do
     # Make sure API is down
     stop_services(["nginx", "opscode-erchef"])
 
-    start_services(["postgresql", "rabbitmq", "opscode-solr4"])
+    start_services(["rabbitmq", "opscode-solr4"])
 
     force_restart_service("opscode-chef-mover")
 
@@ -15,7 +15,7 @@ define_upgrade do
                 "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " \
                 "mover_reindex_migration_callback normal")
 
-    stop_services(["opscode-chef-mover", "postgresql", "opscode-solr4", "rabbitmq"])
+    stop_services(["opscode-chef-mover", "opscode-solr4", "rabbitmq"])
 
   end
 end

--- a/files/private-chef-upgrades/001/019_org_assoc_invites_global_groups_migration.rb
+++ b/files/private-chef-upgrades/001/019_org_assoc_invites_global_groups_migration.rb
@@ -6,8 +6,6 @@ define_upgrade do
     # Make sure API is down
     stop_services(["nginx", "opscode-erchef"])
 
-    start_service('postgresql')
-
     force_restart_service("opscode-chef-mover")
 
     log "Migrating organizations..."
@@ -32,7 +30,7 @@ define_upgrade do
 
     # TODO: add log parsing to ensure migration succeeded
 
-    stop_services(["opscode-chef-mover", "postgresql"])
+    stop_service("opscode-chef-mover")
 
   end
 end

--- a/partybus/lib/partybus/migration_api/v1.rb
+++ b/partybus/lib/partybus/migration_api/v1.rb
@@ -67,33 +67,33 @@ EOF
       def force_restart_service(service_name)
         log("\tRestarting Service #{service_name}")
         service_manager = Partybus::ServiceManager.new
-        service_manager.force_restart_service(service_name, 60)
+        service_manager.force_restart_service(service_name, 15)
       end
 
       def start_service(service_name)
         log("\tStarting Service #{service_name}")
         service_manager = Partybus::ServiceManager.new
         # 100 seconds sleep time by default
-        service_manager.start_service(service_name, 60)
+        service_manager.start_service(service_name, 15)
       end
 
       def start_services(service_array)
         log("\tStarting Services #{service_array}")
         service_manager = Partybus::ServiceManager.new
         # 100 seconds sleep time by default
-        service_manager.start_services(service_array, 60)
+        service_manager.start_services(service_array, 15)
       end
 
       def stop_service(service_name)
         log("\tStopping Service #{service_name}")
         service_manager = Partybus::ServiceManager.new
-        service_manager.stop_service(service_name, 30)
+        service_manager.stop_service(service_name, 10)
       end
 
       def stop_services(service_array)
         log("\tStopping Services #{service_array}")
         service_manager = Partybus::ServiceManager.new
-        service_manager.stop_services(service_array, 60)
+        service_manager.stop_services(service_array, 10)
       end
 
       def run_command(command, options={})


### PR DESCRIPTION
Change the upgrade process assumptions so that it assumes postgres is up since there are no upgrades that need it to be down. Shorten sleep times to be more reasonable (should really just be mover restarting now).

Ultimately we should fix `pcc status` to actually say ready when services can take requests, but that would require per-request coding that won't happen before monday.

[Passing build](http://wilson.ci.opscode.us/job/chef-server-12-trigger-ad_hoc/19/downstreambuildview/)
