### PR TITLE
opscode-reporting chef-server-running back-compat

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -245,7 +245,16 @@ file "/etc/opscode/chef-server-running.json" do
   owner node["private_chef"]["user"]["username"]
   group "root"
   mode "0600"
-  content Chef::JSONCompat.to_json_pretty({ "private_chef" => node['private_chef'].to_hash,
-                                            "run_list" => node.run_list,
-                                            "runit" => node['runit'].to_hash})
+
+  file_content = {
+    "private_chef" => node['private_chef'].to_hash,
+    "run_list" => node.run_list,
+    "runit" => node['runit'].to_hash
+  }
+  # back-compat fixes for opscode-reporting
+  # reporting uses the opscode-solr key for determining the location of the solr host,
+  # so we'll copy the contents over from opscode-solr4
+  file_content['private_chef']['opscode-solr'] = file_content['private_chef']['opscode-solr4']
+
+  content Chef::JSONCompat.to_json_pretty(file_content)
 end


### PR DESCRIPTION
Because we've moved the opscode-solr resource to opscode-solr4,
opscode-reporting can no longer find the correct configuration
values in the chef-server-running json file when tyring to configure
the search attributes.

This fixes by re-adding the ospcode-solr key that is a copy of the
newly-named opscode-solr4. This can be removed when reporting is
updated to use the new fields.

/cc @opscode/server-team @jamesc 
