### PR TITLE
Update to use oc_erchef 0.27.2

### DIFF
--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-default_version "0.27.1"
+default_version "0.27.2"
 
 dependency "erlang"
 dependency "rebar"


### PR DESCRIPTION
This picks up the work to return the GUID from the organizations/:orgname endpoint

http://wilson.ci.opscode.us/job/chef-server-12-trigger-ad_hoc/24/downstreambuildview/
