### PR TITLE
fix post-12 cleanup for HA installs

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -63,6 +63,11 @@ default['private_chef']['couchdb']['vip'] = "127.0.0.1"
 default['private_chef']['couchdb']['port'] = 5984
 
 ####
+# Opscode Solr (legacy required for upgrade cleanup to work)
+####
+default['private_chef']['opscode-solr']['data_dir'] = "/var/opt/opscode/opscode-solr/data"
+
+####
 # RabbitMQ
 ####
 default['private_chef']['rabbitmq']['enable'] = true

--- a/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -214,7 +214,6 @@ module PrivateChef
         "opscode_chef",
         "redis_lb",
         "addons",
-        "couchdb",
         "rabbitmq",
         "opscode_solr4",
         "opscode_expander",
@@ -235,7 +234,11 @@ module PrivateChef
         "user",
         "ha",
         "disabled_plugins",
-        "enabled_plugins"
+        "enabled_plugins",
+
+        # keys for cleanup and back-compat
+        "couchdb",
+        "opscode_solr"
       ].each do |key|
         # @todo: Just pick a naming convention and adhere to it
         # consistently
@@ -274,11 +277,17 @@ module PrivateChef
       PrivateChef["enabled_plugins"] << "chef-ha-#{PrivateChef["ha"]["provider"]}"
       PrivateChef["ha"]["path"] ||= "/var/opt/opscode/drbd/data"
       hapath = PrivateChef["ha"]["path"]
-      PrivateChef["couchdb"]["data_dir"] ||= "#{hapath}/couchdb"
       PrivateChef['bookshelf']['data_dir'] = "#{hapath}/bookshelf"
       PrivateChef["rabbitmq"]["data_dir"] ||= "#{hapath}/rabbitmq"
       PrivateChef["opscode_solr4"]["data_dir"] ||= "#{hapath}/opscode-solr4"
       PrivateChef["redis_lb"]["data_dir"] ||= "#{hapath}/redis_lb"
+
+      # cleanup back-compat
+      # in order to delete the data directories for opscode-solr and couchdb
+      # after installing Chef Server 12, we need to have access to the configuration
+      # data as if it were configured for Enterprise Chef 11.
+      PrivateChef['couchdb']['data_dir'] = "#{hapath}/couchdb"
+      PrivateChef['opscode_solr']['data_dir'] = "#{hapath}/opscode-solr"
 
       # The postgresql data directory is scoped to the current version;
       # changes in the directory trigger upgrades from an old PostgreSQL

--- a/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -254,7 +254,10 @@ file "/etc/opscode/chef-server-running.json" do
   # back-compat fixes for opscode-reporting
   # reporting uses the opscode-solr key for determining the location of the solr host,
   # so we'll copy the contents over from opscode-solr4
-  file_content['private_chef']['opscode-solr'] = file_content['private_chef']['opscode-solr4']
+  file_content['private_chef']['opscode-solr'] ||= {}
+  %w{vip port}.each do |key|
+    file_content['private_chef']['opscode-solr'][key] = file_content['private_chef']['opscode-solr4'][key]
+  end
 
   content Chef::JSONCompat.to_json_pretty(file_content)
 end

--- a/files/private-chef-cookbooks/private-chef/recipes/post_12_upgrade_cleanup.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/post_12_upgrade_cleanup.rb
@@ -15,13 +15,14 @@ private_chef_package_cleaner "opscode-webui" do
 end
 
 private_chef_package_cleaner "opscode-solr" do
-  directories ["/var/opt/opscode/opscode-solr",
+  directories ["/var/opt/opscode/opscode-solr",                  # solr app binaries here
+               node['private_chef']['opscode-solr']['data_dir'], # solr data here
                "/var/log/opscode/opscode-solr"]
   files ["/etc/opscode/logrotate.d/opscode-solr"]
 end
 
 private_chef_package_cleaner "couchdb" do
-  directories ["/var/opt/opscode/couchdb",
+  directories [node['private_chef']['couchdb']['data_dir'],
                "/var/log/opscode/couchdb"]
   files ["/etc/cron.d/couchdb_compact",
          "/etc/cron.d/couchdb_bounce",


### PR DESCRIPTION
The previous version of the post-12 cleanup did not take into account
that data directories for databases are in a different location for
HA installs. This change re-populates that data in the
chef-server-running config, and fixes an issue where said config
was storing all of the data for opscode-solr as opscode-solr4, which
would have caused a cleanup to delete all of the opscode-solr4 data.

/cc @opscode/server-team 
