### PR TITLE
Use the X-Forwarded-For header in nginx logs instead of the remote address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 12.0.0 (Unreleased)
 
+### use X-Forwarded-For header in nginx logs if topology is HA
+* in the nginx logs, use $http_x_forwarded_for instead of $remote_addr if
+  node['private_chef']['log_x_forwarded_for'] is true.  The attribute defaults
+  to true if 'topology' is set to 'ha' or 'tier' and false otherwise
+
 ### enterprise-chef-common updated to 0.4.5
 * Fix issue where 'private-chef' was being changed to 'private_chef' unexectedly in upstart/runit files
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@ The following items are new for Enterprise Chef 11.1.5 and/or are changes from p
 * [opscode-platform-debug] Upgrade to rel-0.5.1
 * [private-chef-ctl] Add a gather-logs command to create a tarball of
   important logs and system information.
+* [private-chef-cookbooks] Use X-Forwarded-For header instead of remote address in nginx logs
+  when topology is set to 'ha' or 'tier'
 
 ### Bug Fixes:
 

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -275,6 +275,7 @@ default['private_chef']['nginx']['dir'] = "/var/opt/opscode/nginx"
 default['private_chef']['nginx']['log_directory'] = "/var/log/opscode/nginx"
 default['private_chef']['nginx']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['nginx']['log_rotation']['num_to_keep'] = 10
+default['private_chef']['nginx']['log_x_forwarded_for'] = %w(ha tier).include?(node['private_chef']['topology'])
 default['private_chef']['nginx']['ssl_port'] = 443
 default['private_chef']['nginx']['enable_non_ssl'] = false
 default['private_chef']['nginx']['non_ssl_port'] = 80

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -9,7 +9,7 @@ events {
 }
 
 http {
-<% if ['private_chef']['nginx']['log_x_forwarded_for'] -%>
+<% if node['private_chef']['nginx']['log_x_forwarded_for'] -%>
   log_format opscode '$http_x_forwarded_for - $remote_user [$time_local]  '
 <% else -%>
   log_format opscode '$remote_addr - $remote_user [$time_local]  '

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -9,7 +9,11 @@ events {
 }
 
 http {
+<% if ['private_chef']['nginx']['log_x_forwarded_for'] -%>
+  log_format opscode '$http_x_forwarded_for - $remote_user [$time_local]  '
+<% else -%>
   log_format opscode '$remote_addr - $remote_user [$time_local]  '
+<% end -%>
                     '"$request" $status "$request_time" $body_bytes_sent '
                     '"$http_referer" "$http_user_agent" "$upstream_addr" "$upstream_status" "$upstream_response_time" "$http_x_chef_version" "$http_x_ops_sign" "$http_x_ops_userid" "$http_x_ops_timestamp" "$http_x_ops_content_hash" $request_length';
 


### PR DESCRIPTION
Use the X-Forwarded-For header in nginx logs instead of the remote address, based on the value of node['private_chef']['nginx']['log_x_forwarded_for'].  This attribute defaults to true if the topology is set to 'ha' or 'tier' and false otherwise.
