### PR TITLE
Default to `lucid` for debian family

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/add_ons_remote.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/add_ons_remote.rb
@@ -11,10 +11,16 @@ when 'debian'
   apt_repository 'chef-stable' do
     uri "https://packagecloud.io/chef/stable/ubuntu/"
     key 'https://packagecloud.io/gpg.key'
-    distribution node['lsb']['codename']
+    distribution 'lucid'
     deb_src true
     trusted true
     components %w( main )
+  end
+
+  # FIXME: We should test on higher versions of ubuntu https://github.com/opscode/opscode-omnibus/issues/460
+  log "Chef Server packages and addons are not regression tested on #{node['platform']}-#{node['platform_version']}. They may install, but may not work, use at your own risk" do
+    level :warn
+    only_if { (platform?('ubuntu') && node['platform_version'].to_f > 12.04) || platform?('debian') }
   end
 
   # Performs an apt-get update


### PR DESCRIPTION
We build packages on Ubuntu 10.04 (lucid), then test them on later versions.
However, not all new versions are tested; currently only Ubuntu, and up to
version 12.04. By defaulting to `lucid` we allow users to install on any
debian-family platform, and we print a log message (or have a resource show in
the output formatter).

Long term we should fix the issue (#460), where we have tester systems for
other Ubuntu versions - in particular Ubuntu 14.04 as it's an LTS.
