### PR TITLE
Bump chef_max_version to 12.

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -253,7 +253,7 @@ default['private_chef']['lb']['redis_connection_pool_size'] = 250
 default['private_chef']['lb']['maint_refresh_interval'] = 600
 default['private_chef']['lb']['ban_refresh_interval'] = 600
 default['private_chef']['lb']['chef_min_version'] = 10
-default['private_chef']['lb']['chef_max_version'] = 11
+default['private_chef']['lb']['chef_max_version'] = 12
 
 ###
 # Load balancer route configuration


### PR DESCRIPTION
Recent versions of ChefDK are shipping a chef executable that
identifies as Chef 12.  Since we are encouraging people to use ChefDK,
we should allow API requests from it.
