### PR TITLE
Changed flavor from 'ec' to 'cs' (chef server)

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -27,7 +27,7 @@ opscode-chef-mover
 # High level options
 ###
 default['private_chef']['api_version'] = "12.0.0"
-default['private_chef']['flavor'] = "ec"
+default['private_chef']['flavor'] = "cs"
 default['private_chef']['install_path'] = "/opt/opscode"
 
 default['private_chef']['notification_email'] = "pc-default@opscode.com"


### PR DESCRIPTION
Now that we have Chef Server Core with Chef 12 (one Chef to rule them all, and in the darkness bind them), change flavor to match.
