### PR TITLE
Add note about chef_max_version bump to 12 to changelog; release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Bump the chef_max_version, which is the max chef client version the Chef server accepts, to be 12.
+
 ### rest server API
 * updated server flavor from 'ec' to 'cs' (Chef Server) now that servers have been merged
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,12 +6,12 @@
 
 The following items are new since Enterprise Chef 11.2.1 and/or are changes from previous versions:
 
+* [opscode-omnibus] The chef_max_version has been bumped to 12, so that Chef clients up to 12 can connect to the server.  
 * [couchdb] has been removed
 * [oc_erchef] 
   *  All endpoints that formerly were in opscode-account are now in erchef and the data
   resides in SQL. This includes containers, groups, organizations, org associations and invites.  
   * Key generation is now in erchef.
-  * 
 
 * [opscode-account] has been removed
 * [opscode-certificate] has been removed


### PR DESCRIPTION
Forgot to add this earlier until @tylercloke's friendly poke.

@opscode/server-team  
