### PR TITLE
Change gather-logs config to chef-server.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bump the chef_max_version to 12 (this is the max chef client version that Chef Server will accept)
 * expose license configuration options
 * Add man page for chef-server-ctl.
+* Correct gather-logs to point to chef-server.rb
 
 ### oc_erchef 0.27.4
 * ldap start_tls support

--- a/files/private-chef-scripts/gather-logs
+++ b/files/private-chef-scripts/gather-logs
@@ -19,8 +19,8 @@ if [[ $type == 'EC' ]];
 then
     path='opscode'
     ctl_cmd='private-chef-ctl'
-    config_name='private-chef.rb'
-    ha=$(egrep -qs 'topology\s+.*ha' /etc/opscode/private-chef.rb)$?
+    config_name='chef-server.rb'
+    ha=$(egrep -qs 'topology\s+.*ha' /etc/opscode/chef-server.rb)$?
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];
     then


### PR DESCRIPTION
Was previously set to private-chef.rb. This covers the case where there's an
existing private-chef.rb that will not get replaced with a symlink.
