### PR TITLE
oc_id 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 ### oc_erchef 0.27.3
 * Fix meck dependency locking issue.
 
+## oc_id 0.4.1
+* Update doorkeeper gem to 1.4.0
+* Add support for Resource Owner Password Credentials flow
+
 ### rest server API
 * removed check for maximum client version (only checks for minimum, i.e., <10)
 * updated server flavor from 'ec' to 'cs' (Chef Server) now that servers have been merged

--- a/config/software/oc_id.rb
+++ b/config/software/oc_id.rb
@@ -1,5 +1,5 @@
 name "oc_id"
-default_version "0.3.3"
+default_version "0.4.1"
 
 dependency "postgresql92" # for libpq
 dependency "nodejs"


### PR DESCRIPTION
Updates oc-id to 0.4.1 
- Update doorkeeper gem to 1.4.0
- Add support for [Resource Owner Password Credentials](http://oauthlib.readthedocs.org/en/latest/oauth2/grants/password.html) flow. You can now exchange your chef username/password for a bearer token.
