### PR TITLE
Update changelog about removal of chef_max_version limit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 * properly configure ldap under erchef, and add some safeguards
   against incorrect encryption configuration.
 * oc_erchef updated to 0.27.4
-* Bump the chef_max_version to 12 (this is the max chef client version that Chef Server will accept)
 * expose license configuration options
 * Add man page for chef-server-ctl.
 * Correct gather-logs to point to chef-server.rb
+* Remove chef_max_version limit. There is no upper boound on the chef client version allowed now.
 
 ### oc_erchef 0.27.4
 * ldap start_tls support


### PR DESCRIPTION
This was missed when this work was merged in.
