### PR TITLE
Disable chef-solo run forking so that ctrl+c kills ctl commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Restricted chef-server-ctl install to known Chef packages
 * Correct show-config command/recipe to point at chef-server.rb instead of private-chef.rb
 * Updated knife-opc config so that user / org / association commands now work if non-default ports are used.
+* re-enable ctrl+c for chef-server-ctl commands by setting "client_fork false" in solo.rb
 
 ### omnibus-ctl 0.3.0
 

--- a/config/software/private-chef-cookbooks.rb
+++ b/config/software/private-chef-cookbooks.rb
@@ -28,6 +28,7 @@ JSON
       f.puts "file_cache_path \"\#\{CURRENT_PATH\}/cache\""
       f.puts "cookbook_path CURRENT_PATH"
       f.puts "verbose_logging true"
+      f.puts "client_fork false"
     end
   end
 end


### PR DESCRIPTION
This allows users to "ctrl+c" chef-server-ctl commands (such as reconfigure).
