### PR TITLE
Bump mover to 2.2.15 and update changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Enterprise Chef Changelog
 
-## 12.0.0.rc5
+## 12.0.0.rc5 (unreleased)
 
 ### opscode-omnibus
 * properly configure ldap under erchef, and add some safeguards
@@ -24,6 +24,10 @@
 ## oc_id 0.4.1
 * Update doorkeeper gem to 1.4.0
 * Add support for Resource Owner Password Credentials flow
+
+### opscode-chef-mover 2.2.15
+* Clean up error handling for org user associations and invites migrations
+* Fix backwards compatibility issues with oc_chef_authz intergration
 
 ### rest server API
 * removed check for maximum client version (only checks for minimum, i.e., <10)

--- a/config/software/opscode-chef-mover.rb
+++ b/config/software/opscode-chef-mover.rb
@@ -1,5 +1,5 @@
 name "opscode-chef-mover"
-default_version "2.2.14"
+default_version "2.2.15"
 
 dependency "erlang"
 dependency "rebar"


### PR DESCRIPTION
Ping @opscode/server-team 
- [Passing Build](http://wilson.ci.opscode.us/job/chef-server-12-trigger-ad_hoc/79/downstreambuildview/)
- Test migration from 11x in dev-vm and it works.
