### PR TITLE
Update to oc_erchef 0.27.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 * Add man page for chef-server-ctl.
 * Correct gather-logs to point to chef-server.rb
 
+### oc_erchef 0.27.7
+* Improve error handling in org creation and deletion.
+
+### oc_erchef 0.27.6
+* Fixed pooler bug with regard to timed out pool member starts
+
+### oc_erchef 0.27.5
+* Add org info to actions
+
 ### oc_erchef 0.27.4
 * ldap start_tls support
 * ldap simple_tls support

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-default_version "0.27.4"
+default_version "0.27.7"
 
 dependency "erlang"
 dependency "rebar"


### PR DESCRIPTION
Integrate 0.27.7, including pooler, reporting, and organizations endpoint enhancements.
@opscode/server-team 
Passes CI; should be ready to go.
