### PR TITLE
Change pid filename as nodename in configuration file

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
@@ -80,7 +80,7 @@ if is_data_master?
     retries 20
   end
 
-  execute "#{rmq_ctl_chpost} wait #{rabbitmq_data_dir}/rabbit@localhost.pid" do
+  execute "#{rmq_ctl_chpost} wait #{rabbitmq_data_dir}/#{rabbitmq['nodename']}.pid" do
     retries 10
   end
 


### PR DESCRIPTION
After change rabbimq node name in chef-server.rb file './chef-server-ctl reconfigure' fails. So I change pid filename as node name in the configuration file.