### PR TITLE
use openssl-1.0.1j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 12.0.0.rc5 (unreleased)
 
+### openssl - 1.0.1j
+- SRTP Memory Leak (CVE-2014-3513)
+- Session Ticket Memory Leak (CVE-2014-3567)
+- Build option no-ssl3 is incomplete (CVE-2014-3568)
+
 ### opscode-omnibus
 * properly configure ldap under erchef, and add some safeguards
   against incorrect encryption configuration.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git://github.com/opscode/omnibus-software.git
-  revision: a974609f94b190a4c99ce13ac3857f0b027b0994
-  branch: omnibus/3.2-stable
-  specs:
-    omnibus-software (3.0.0)
-
-GIT
   remote: git://github.com/opscode/omnibus-ruby.git
   revision: 5c8ce5831f2cb6b77ea437aae451fc61c23a2602
   branch: 3.0-stable
@@ -17,6 +10,13 @@ GIT
       ohai (~> 7.2)
       thor (~> 0.18)
       uber-s3
+
+GIT
+  remote: git://github.com/opscode/omnibus-software.git
+  revision: 8e6c54dfe1f14d33655a25e8adb6901064f90c1a
+  branch: omnibus/3.2-stable
+  specs:
+    omnibus-software (3.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Enterprise Chef Release Notes
 
+## 12.0.0.rc5
+ * [openssl] openssl has been updated to 1.0.1j to address
+   CVE-2014-3513, CVE-2014-3567, and CVE-2014-3568
+
 ## 12.0.0.rc4 (2014-09-17)
 
 ### Security Fixes


### PR DESCRIPTION
- update to openssl-1.0.1j by updating omnibus-software lock. Passed CI last night, made additional updates for readme/changelog this morning.
  ping @opscode/server-team 
