### PR TITLE
Lock `cacerts` to `2014.08.20`

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -9,6 +9,7 @@ install_dir     "/opt/opscode"
 build_version   Omnibus::BuildVersion.new.semver
 build_iteration 1
 
+override :cacerts, version: '2014.08.20'
 override :rebar, version: "2.0.0"
 override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"


### PR DESCRIPTION
The latest version (2014.09.03) causes `berks install` commands to fail with:

```
 /opt/opscode/embedded/lib/ruby/1.9.1/net/http.rb:800:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)
```

We only noticed this issue because a new EL6 builder was deployed which hadn't fully warmed it's git cache.

/cc @opscode/release-engineers @opscode/server-team 
