### PR TITLE
Revert "Merge pull request #559 from opscode/of/oc_erchef_in_11_stable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Enterprise Chef Changelog
 
+## 11.2.5 (Unreleased)
+
+### oc-chef-pedant 1.0.29.5
+* Revert to 1.0.29.5 for addon compatibility
+
+### oc-erchef 0.25.14.2
+* Revert to 0.25.14.2 for addon compatibility
+
 ## 11.2.4 (2014-10-27)
 
 ### oc-chef-pedant 1.0.62

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,13 @@
 
 ## 11.2.5 (Unreleased)
 
-### What's New
-
 ### Bug Fixes:
 
 ## 11.2.4 (2014-10-27)
+
+The following items are the set of bug fixes that have been applied since Enterprise Chef 11.2.4:
+
+* oc_erchef 0.25.14.2 - Reverting to previous version for addon compatibility
 
 ### What's New
 

--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-default_version "1.0.62"
+default_version "1.0.29.5"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -1,5 +1,5 @@
 name "oc_erchef"
-default_version "0.28.3"
+default_version "0.25.14.2"
 
 dependency "erlang"
 dependency "rebar"

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -20,10 +20,6 @@ default['private_chef']['install_path'] = "/opt/opscode"
 default['private_chef']['notification_email'] = "pc-default@opscode.com"
 default['private_chef']['from_email'] = '"Opscode" <donotreply@opscode.com>'
 default['private_chef']['role'] = "standalone"
-default['private_chef']['license']['nodes'] = 25
-default['private_chef']['license']['upgrade_url'] = "http://www.getchef.com/contact/on-premises-simple"
-
-default['private_chef']['default_orgname'] = nil
 
 ####
 # The Chef User that services run as
@@ -163,7 +159,7 @@ default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 # Default: generate signed URLs based upon Host: header. Override with a url, "http:// ..."
 default['private_chef']['opscode-erchef']['base_resource_url'] = :host_header
 default['private_chef']['opscode-erchef']['s3_bucket'] = 'bookshelf'
-default['private_chef']['opscode-erchef']['s3_url_ttl'] = 28800
+default['private_chef']['opscode-erchef']['s3_url_ttl'] = 900
 default['private_chef']['opscode-erchef']['s3_parallel_ops_timeout'] = 5000
 default['private_chef']['opscode-erchef']['s3_parallel_ops_fanout'] = 20
 default['private_chef']['opscode-erchef']['authz_timeout'] = 2000
@@ -172,7 +168,6 @@ default['private_chef']['opscode-erchef']['root_metric_key'] = "chefAPI"
 default['private_chef']['opscode-erchef']['depsolver_worker_count'] = 5
 default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['max_request_size'] = 1000000
-default['private_chef']['opscode-erchef']['cleanup_batch_size'] = 0
 
 ###
 # Legacy path (required for cookbok migration)
@@ -277,10 +272,6 @@ default['private_chef']['lb']['chef_min_version'] = 10
 default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = true
 default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = true
-default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = true
-default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = true
-default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = true
-default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = true
 
 ####
 # Nginx
@@ -526,13 +517,6 @@ default['private_chef']['opscode-chef-mover']['cache_ttl'] = '3600'
 default['private_chef']['opscode-chef-mover']['db_pool_size'] = '5'
 default['private_chef']['opscode-chef-mover']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-chef-mover']['ibrowse_max_pipeline_size'] = 1
-default['private_chef']['opscode-chef-mover']['solr_timeout'] = 30000
-default['private_chef']['opscode-chef-mover']['solr_http_init_count'] = 25
-default['private_chef']['opscode-chef-mover']['solr_http_max_count'] = 100
-default['private_chef']['opscode-chef-mover']['solr_http_cull_interval'] = "{1, min}"
-default['private_chef']['opscode-chef-mover']['solr_http_max_age'] = "{70, sec}"
-default['private_chef']['opscode-chef-mover']['solr_http_max_connection_duration'] = "{70,sec}"
-default['private_chef']['opscode-chef-mover']['solr_ibrowse_options'] = "[{connect_timeout, 10000}]"
 
 ###
 # Opscode Test

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -52,11 +52,18 @@
           %% opscode-chef-mover, FWIW.
           {error_logger_hwm, 1000}
         ]},
+ {oc_chef_action, [
+              {actions_host, "<%= node['private_chef']['rabbitmq']['vip'] %>"},
+              {actions_port, <%= node['private_chef']['rabbitmq']['node_port'] %> },
+              {actions_user, <<"<%= node['private_chef']['rabbitmq']['user'] %>">>},
+              {actions_password, <<"<%= node['private_chef']['rabbitmq']['password'] %>">>},
+              {actions_vhost, <<"<%= node['private_chef']['rabbitmq']['actions_vhost'] %>">>},
+              {actions_exchange, <<"<%= node['private_chef']['rabbitmq']['actions_exchange'] %>">>},
+              {actions_fqdn, <<" <%= node['private_chef']['lb']['api_fqdn'] %> ">>}
+             ]},
  {oc_chef_wm, [
               {api_version, "<%= node['private_chef']['api_version'] %>"},
               {server_flavor, "<%= node['private_chef']['flavor'] %>"},
-
-              {default_orgname, <%= node['private_chef']['default_orgname'] ? "<<\"#{node['private_chef']['default_orgname']}\">>" : "undefined" %> },
 
               {ip, "<%= @listen %>"},
               {port, <%= @port %>},
@@ -66,29 +73,15 @@
               %% how many nodes are deserialized at a time in
               %% preparing a response.
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
-	          {superusers, [<<"pivotal">>]},
+	      {superusers, [<<"pivotal">>]},
               %% metrics config
               {root_metric_key, "<%= @root_metric_key %>"},
 
               {authz_timeout, <%= node['private_chef']['opscode-erchef']['authz_timeout'] %>},
               {authz_fanout, <%= node['private_chef']['opscode-erchef']['authz_fanout'] %>},
 
-              {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>},
-              {ldap, []},
-              %% these are used for reporting on license status on the
-              %% license endpoint; it would have been nice to give these
-              %% their own logical section, but erlang requires these to
-              %% be part of a loaded application
-              {node_license, <%= node['private_chef']['license']['nodes'] %>},
-              {upgrade_url, <<"<%= node['private_chef']['license']['upgrade_url'] %>">>},
-              {actions_host, "<%= node['private_chef']['rabbitmq']['vip'] %>"},
-              {actions_port, <%= node['private_chef']['rabbitmq']['node_port'] %> },
-              {actions_user, <<"<%= node['private_chef']['rabbitmq']['user'] %>">>},
-              {actions_password, <<"<%= node['private_chef']['rabbitmq']['password'] %>">>},
-              {actions_vhost, <<"<%= node['private_chef']['rabbitmq']['actions_vhost'] %>">>},
-              {actions_exchange, <<"<%= node['private_chef']['rabbitmq']['actions_exchange'] %>">>},
-              {actions_fqdn, <<"<%= node['private_chef']['lb']['api_fqdn'] %>">>}
-            ]},
+              {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>}
+             ]},
   {chef_wm, [
              {max_request_size, <%= node['private_chef']['opscode-erchef']['max_request_size'] %>},
              {server_version, "<%= node['private_chef']['version'] %>"},
@@ -133,6 +126,7 @@
                 {solr_url, "http://<%= @helper.vip_for_uri('opscode-solr') %>:<%= node['private_chef']['opscode-solr']['port'] %>/solr"}
                ]},
   {chef_objects, [
+                  {certificate_root_url, "http://<%= @helper.vip_for_uri('opscode-certificate') %>:<%= node['private_chef']['opscode-certificate']['port'] %>/certificates"},
                   {s3_access_key_id, "<%= node['private_chef']['bookshelf']['access_key_id'] %>"},
                   {s3_secret_key_id, "<%= node['private_chef']['bookshelf']['secret_access_key'] %>"},
                   {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>"},

--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -5,29 +5,22 @@
 
 ################################################################################
 
-# A unique identification string used to create orgs and users specific
-# to a each single chef server's nodes' OS. Simply using "Process.pid"
-# proved to not be unique enough when running pedant simultaneously
-# on multiple nodes of the same chef server when the generated pedant
-# config file could have been copied across during the setup of that
-# chef server. 
-chef_server_uid = "<%= @hostname %>_#{Process.pid}"
-
 # Specify a testing organization if you are testing a multi-tenant
 # instance of a Chef Server (e.g., Private Chef, Hosted Chef).  If you
 # are testing a single-tenant instance (i.e. Open Source Chef Server),
 # DO NOT include this parameter
 #
 # Due to how the current org cache operates, it is best to use a
-# unique name for your testing organization. If you do not use a
-# unique name and run tests several times (destroying the organization
-# between runs) you will likely get inconsistent results.
+# randomized name for your testing organization (hence the embedded
+# Process.pid).  If you do not use a randomized name and run tests
+# several times (destroying the organization between runs) you will
+# likely get inconsistent results.
 #
 # If you wish Pedant to create the organization for you at test time,
 # include the `:create_me => true` pair.  If you wish to use an
 # existing organization for tests, you should supply a `:validator_key
 # => "/full/path/to/key.pem"` pair
-org({:name => "pedant_testorg_#{chef_server_uid}",
+org({:name => "pedant-testorg-#{Process.pid}",
      :create_me => true})
 
 # org({:name => "existing_org",
@@ -44,11 +37,6 @@ delete_org true
 # You MUST specify the address of the server the API requests will be
 # sent to.  Only specify protocol, hostname, and port.
 chef_server "<%= @api_url %>"
-
-# This configration specifies the default orgname. Note that it does *not*
-# mean that Pedant will test things with default org urls. To do that,
-# pass --use-default-org on the command line
-default_orgname <%= @default_orgname ? "\"#{@default_orgname}\"" : "nil" %>
 
 # If you are doing development testing, you can specify the address of
 # the Solr server.  The presence of this parameter will enable tests
@@ -101,18 +89,18 @@ webui_key '/etc/opscode/webui_priv.pem'
 requestors({
              :clients => {
                :admin => {
-                 :name => "pedant_admin_client_#{chef_server_uid}",
+                 :name => "pedant_admin_client",
                  :create_me => true,
                  :create_knife => true,
                  :admin => true
                },
                :non_admin => {
-                 :name => "pedant_client_#{chef_server_uid}",
+                 :name => 'pedant_client',
                  :create_me => true,
                  :create_knife => true,
                },
                :bad => {
-                 :name => "bad_client_#{chef_server_uid}",
+                 :name => 'bad_client',
                  :create_me => true,
                  :bogus => true
                }
@@ -121,14 +109,14 @@ requestors({
              :users => {
                # An administrator in the testing organization
                :admin => {
-                 :name => "pedant_admin_user_#{chef_server_uid}",
+                 :name => "pedant_admin_user",
                  :create_me => true,
                  :create_knife => true,
                  :admin => true
                },
 
                :non_admin => {
-                 :name => "pedant_user_#{chef_server_uid}",
+                 :name => "pedant_user",
                  :create_me => true,
                  :create_knife => true,
                  :admin => false
@@ -136,7 +124,7 @@ requestors({
 
                # A user that is not a member of the testing organization
                :bad => {
-                 :name => "pedant_nobody_#{chef_server_uid}",
+                 :name => "pedant-nobody",
                  :create_me => true,
                  :create_knife => true,
                  :associate => false
@@ -164,15 +152,9 @@ ruby_role_endpoint?        false
 ruby_cookbook_endpoint?    false
 ruby_client_endpoint?      false
 ruby_users_endpoint?       true
-ruby_container_endpoint?   true
-ruby_container_endpoint_in_sql? false
-ruby_group_endpoint?       true
-ruby_acl_endpoint?         true
-ruby_system_recovery_endpoint? true
-ruby_org_acl_endpoint?     true
-ruby_org_assoc?            true
-ruby_organizations_endpoint? true
-chef_12?                   false
+ruby_container_endpoint?   <%= node['private_chef']['lb']['xdl_defaults']['couchdb_containers'] %>
+ruby_container_endpoint_in_sql?  <%= !node['private_chef']['lb']['xdl_defaults']['couchdb_containers'] %>
+ruby_group_endpoint?       <%= node['private_chef']['lb']['xdl_defaults']['couchdb_groups'] %>
 
 old_runlists_and_search true
 


### PR DESCRIPTION
This reverts commit 806e6d13f00c15a390af63e98e4d09f13e826cb5, reversing
changes made to 08098a59805b6f87b9e58d1f4eca58bbe1a3c317.

This commit rolls back the Erchef API to a version that defaults
darklaunch features to CouchDB mode. This behavior is needed for
existing enterprise addons that expect to be able to make API requests
directly to the Erchef service, and not through the Nginx reverse
proxy, which sets correct darklaunch headers.

Further work will need to be done to back-port the latest Erchef
service and retain this default behavior.
