### PR TITLE
Add a note about the switch to chef-server.rb to changelog, releasenotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@
 
 ### Renamed chef server core instead of Private Chef or Enterprise Chef.
 
+### opscode-omnibus
+* Change to using /etc/opscode/chef-server.rb from /etc/opscode/private-chef.rb
+* Symlink private-chef.rb to chef-server.rb if private-chef.rb is present
+
 ### bookshelf 1.1.4
 * Erlang R16 support
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,10 @@
 * [opscode-omnibus] Ensure contents of install dir (/opt/opscode) are owned by root.
 
 ## 12.0.0
+* /ect/opscode/chef-server.rb is the new configuration file for the server and /etc/opscode/private-chef.rb is deprecated.
+  If private-chef.rb is found on the system it will be symlinked into place if chef-server.rb is not
+  present on the system or is empty.
+
 
 ### What's New:
 


### PR DESCRIPTION
With Chef Server 12, /etc/opscode/chef-server.rb is the place for server
configuration and /etc/opscode/private-chef.rb is deprecated. Note this
in the changelog and release notes.
