### PR TITLE
Respect the max shared mem lists for postgresql.  Issue #597

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * added apt-transport-https package in case it was missing from the system (packagecloud requires it)
 * created chef-server.rb during install to cut down on user confusion
 * Change postgres effective_cache_size to 50% of available RAM instead of hard coding at 128MB
+* [opscode-omnibus-597] Limit postgresql shared memory usage to stay under SHMAX
 
 ### private-chef-cookbooks
 * [OC-11769] make oc_chef_authz a tunable in private-chef.rb

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Fix oc_chef_authz timeout tunable
 * Make postgresql slow query logging configurable
 * Adjust perms to 0750 for all service's log dir
+* [opcode-omnibus-597] Ensure postgresql is set with shared memory less than SHMAX.
 
 ## 12.0.0.rc5 (2014-10-17)
  * [openssl] openssl has been updated to 1.0.1j to address


### PR DESCRIPTION
This is based on this[1] patch to the open source server.  I looked at [2] for guidance, though it doesn't say much about what to do on the upper end.  It probably makes sense to have have some sort of hard ceiling, but I'm not sure where that should be.  I totally made up the 15% head room based on what % the old patch had.

[1] https://github.com/opscode/omnibus-chef/commit/ebd19785a1d65f10245aa96714b8d3dfc57de41f
[2] https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
