### PR TITLE
Use remote_file to get gpg key used to verify CS add on installs for RHEL.

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -42,6 +42,10 @@ dependency "pg-gem" # used by private-chef-ctl reconfigure
 # without manage installed.
 dependency "knife-opc-gem"
 
+# download the gpg-key beforehand for rhel systems to
+# use when verifying add ons
+dependency "gpg-key"
+
 dependency "keepalived"
 dependency "bookshelf"
 

--- a/config/software/gpg-key.rb
+++ b/config/software/gpg-key.rb
@@ -1,0 +1,35 @@
+#
+# Author:: Tyler Cloke (<tyler@getchef.com>)
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# some versions of rhel yum does not support ssl protocol SNI, which is what
+# cloudfront uses which is where the gpg key is stored. use remote_file to
+# store the key locally so rhel can use it when verifying add ons
+name "gpg-key"
+default_version "1.0.0"
+
+version "1.0.0" do
+  source md5: "c8f49b137b190707a0c5f5702a147155"
+end
+
+source url: "https://downloads.getchef.com/chef.gpg.key"
+
+build do
+  mkdir "#{install_dir}/embedded/keys"
+  copy "#{project_dir}/chef.gpg.key", "#{install_dir}/embedded/keys/chef.gpg.key"
+end

--- a/files/private-chef-cookbooks/private-chef/recipes/add_ons_remote.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/add_ons_remote.rb
@@ -26,10 +26,12 @@ when 'rhel'
 
   major_version = node['platform_version'].split('.').first
 
+  gpg_key_path = File.join(node['private_chef']['install_path'], "/embedded/keys/chef.gpg.key")
+
   yum_repository 'chef-stable' do
     description 'Chef Stable Repo'
     baseurl "https://packagecloud.io/chef/stable/el/#{major_version}/$basearch"
-    gpgkey 'https://downloads.getchef.com/chef.gpg.key'
+    gpgkey "file://#{gpg_key_path}"
     sslverify true
     sslcacert '/etc/pki/tls/certs/ca-bundle.crt'
     gpgcheck true


### PR DESCRIPTION
Ping @opscode/server-team 

RHEL5 yum does not support ssl protocol SNI, which is what cloudfront uses
which is where the gpg key is stored. Use remote_file to get the key because
it has SNI support, and download the key locally to verify on RHEL5.

[Running Build](http://wilson.ci.opscode.us/job/chef-server-12-trigger-ad_hoc/159/downstreambuildview/)

Fixes https://github.com/opscode/opscode-omnibus/issues/497
