### PR TITLE
make ldap config sane and don't break cs11 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 ### opscode-omnibus
 * Add ability to configure SQL query timeout for Erchef, bifrost and mover.
 * Provide reasonable default for LDAP and LDAPS ports.
+* Deprecate ldap "encryption" setting and replace with
+  `ssl_enabled`/`tls_enabled`. Add further validation and sanity checks around
+  ldap settings, as well as deprecation warnings.
 * Add ability to configure timeout for connect() when connecting to backends.
 
 ### oc\_erchef 0.29.4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,11 @@ The following items are new since Enterprise Chef 11.2.1 and/or are changes from
     you when you upgrade.
   * If you do not have a `private-chef.rb` or `chef-server.rb`, a `chef-server.rb`
     will be created for you at installation.
+* LDAP
+  * STARTTLS is now properly supported for LDAP.  If your LDAP server supports it
+    you can enable it via `ldap['start_tls'] = true` in `/etc/opscode/chef-server.rb`.
+  * the `ldap['encryption']` setting is deprecated. (See Deprecations
+    section, below.)
 * chef-server-ctl
   * `chef-server-ctl` replaces `private-chef-ctl` though
     `private-chef-ctl` will also work in CS12.
@@ -134,9 +139,15 @@ To help prevent this class of troubles, Chef Server now enforces that a
 member of an organization's "admins" group cannot be removed from the
 organization without first being removed from the "admins" group.
 
+### Deprecations
+
+* The setting ldap['encryption'] is now deprecated. Instead use
+  `ldap['ssl_enabled'] = true` or `ldap['tls_enabled'] = true` as appropriate
+  to your environment.
 
 ### Release History
 
+* RC7 2014-11-20
 * RC6 2014-11-11
 * RC5 2014-10-17
 * RC4 2014-09-18

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -567,14 +567,10 @@ default['private_chef']['ldap'] = nil
 # default['private_chef']['ldap']['bind_password'] = "plaintext password for binding w/ bind_dn"
 # default['private_chef']['ldap']['base_dn'] = "OU=Employees,OU=Domain users,DC=example,DC=com"
 # default['private_chef']['ldap']['timeout'] = 60000
+# default['private_chef']['ldap']['port'] = 389
 #
-# # Ensure that if you are using ssl-enabled ldap that you set port
-# # correctly (usually  636) AND that you set encryption to simple_tls
-# default['private_chef']['ldap']['port'] = 636
-#
-# Supported values: :none (or nil), :simple_tls, :start_tls
-# Default: :none
-# default['private_chef']['ldap']['encryption'] = :simple_tls
+# default['private_chef']['ldap']['enable_ssl'] = false
+# default['private_chef']['ldap']['enable_tls'] = false
 
 ##
 # Upgrades/Partybus

--- a/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -221,11 +221,10 @@ EOKEY
       "http://#{vip_for_uri('lb_internal')}:#{node['private_chef']['nginx']['non_ssl_port']}"
     end
   end
-end
 
-class Chef::Resource::Template
   def ldap_authentication_enabled?
     node['private_chef'].attribute?('ldap') &&
       !(node['private_chef']['ldap'].nil? || node['private_chef']['ldap'].empty?)
   end
 end
+

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -77,18 +77,13 @@
               {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>},
               <% if @ldap_enabled -%>
               {ldap, [{host, "<%= @helper.normalize_host(node['private_chef']['ldap']['host']) || "localhost" %>"},
-                      % The default port for ldap over ssl (simple_tls) is 636.  The standard ldap port without ssl (even
-                      % if upgrading to secure via start_tls) is 389.
-                      {port, <%= node['private_chef']['ldap']['port'] || (@ldap_encryption == "simple_tls" ? 636 : 389) %> },
+                      {port, <%= node['private_chef']['ldap']['port'] || (@ssl_enabled ? 636 : 389) %> },
                       {timeout, <%= node['private_chef']['ldap']['timeout'] || 60000 %> },
                       {bind_dn, "<%= node['private_chef']['ldap']['bind_dn'] || "" %>" },
                       {bind_password, "<%= node['private_chef']['ldap']['bind_password'] || "" %>" },
                       {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
                       {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },
-                      % Note that encryption value of simple_tls is required to use ssl - the ssl_enabled configuration
-                      % entry is ignored, as it was under opscode-account. ENsure that port is set correctly if this is
-                      % set to simple_tls.
-                      {encryption, <%= @ldap_encryption %>}
+                      {encryption, <%= @ldap_encryption_type %>}
               ]},
               <% else -%>
               {ldap, []},


### PR DESCRIPTION
WIP - testing still in progress. 

ping @opscode/server-team 

So @kwilczynski and I discussed this a bit and concluded that the removal of `enable_ssl` broke backwards compatibility with ldap configuration under EC11.  In addition, it's kind of confusing - the term `simple_tls` is not a meaningful one, but we used it to indicate ssl suppor. (This was a holdover from  net/ldap   we used in opscode-account, which apparently dubbed ssl 'simple-tls'). Further, we accepted a value of 'start_tls', but research so far shows that we ignored it if specified (further verification needed, but I do not _think_ net/ldap supported this).

This change tries to simplify things: 
- deprecates the 'encryption' setting - since we're only ever using two values, having a freeform type makes no sense. 
- reinstate enable_ssl.  It will now work as it used to: if you specify it in configuration, we will make an SSL connection to the ldap  host from oc_erchef. 
- add enable_tls. If specified, we will upgrade to a secure connection via the STARTTLS command after establishing the connection to the ldap server 
- if enable_ssl is set, use standard default ssl port if  port is not configured
- permit 'encryption' values of 'start_tls' and 'simple_tls', but warn that they are deprecated
- fail if we see an unknown `encryption` value; or if both `enable_ssl` and `enable_tls` are specified (they are mutually exclusive). 

Another commit will be made to add changelog and release notes entries.

/cc @jamescott for incoming documentation and release notes changes 
