### PR TITLE
disable the open source chef server 11 services on reconfigure

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -257,6 +257,7 @@ include_recipe "private-chef::oc-chef-pedant"
 include_recipe "private-chef::log_cleanup"
 include_recipe "private-chef::partybus"
 include_recipe "private-chef::ctl_config"
+include_recipe "private-chef::disable_chef_server_11"
 
 file "/etc/opscode/chef-server-running.json" do
   owner OmnibusHelper.new(node).ownership['owner']

--- a/files/private-chef-cookbooks/private-chef/recipes/disable_chef_server_11.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/disable_chef_server_11.rb
@@ -1,0 +1,21 @@
+open_source_11_sv_dir = "/opt/chef-server/sv"
+
+return unless Dir.exist?(open_source_11_sv_dir)
+
+# find all of the directory entries in the sv_dir that are
+# not hidden, '..', or '.'.
+services = Dir.new(open_source_11_sv_dir).entries.select do |d|
+  File.directory?(File.expand_path(d, open_source_11_sv_dir)) &&
+    !/\..*/.match(d)
+end
+
+services.each do |sv_entry|
+  sv_dir = File.expand_path(sv_entry, open_source_11_sv_dir)
+  down_file = File.expand_path("down", sv_dir)
+  file down_file do
+    owner "root"
+    group "root"
+    mode   0644
+    content ""
+  end
+end


### PR DESCRIPTION
This, combined with updated documentation on how to handle the running runsvdir and runsv processes from Chef 11, contribute to address https://github.com/opscode/chef-server/issues/25.

This PR writes a down file into the service directory for each of the Chef Server 11 services, ensuring that they will not start up by default on a node reboot or when the Chef 11 runsvdir process gets restarted.

/cc @opscode/server-team @jeremiahsnapp @stevendanna 
