### PR TITLE
mixlib-shellout update to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Chef Server Changelog
+## 12.0.1 (unreleased)
+
+### oc-chef-pedant 1.0.68
+* pin mixlib-shellout to 1.6.1
+
+### opscode-omnibus
+* pin mixlib-shellout to 1.6.1
 
 ## 12.0.0 (2014-11-25)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     ohai (7.4.0)
       ffi (~> 1.9)
       ffi-yajl (~> 1.0)

--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -1,5 +1,5 @@
 name "oc-chef-pedant"
-default_version "1.0.67"
+default_version "1.0.68"
 
 dependency "ruby"
 dependency "bundler"


### PR DESCRIPTION
- Update lockfile for repo to pin 1.6.1
- pull in 1.0.68 of oc-chef-pedant which contains the same change

ping @opscode/server-team 
