### PR TITLE
Runit should wait for drdb before starting backend services

### DIFF
--- a/files/private-chef-cookbooks/chef-ha-drbd/templates/default/ha_backend_storage_drbd.erb
+++ b/files/private-chef-cookbooks/chef-ha-drbd/templates/default/ha_backend_storage_drbd.erb
@@ -7,6 +7,10 @@ function log_me
   echo "$(date -R): ${1}" >> $LOGNAME
 }
 
+is_drbd_mounted() {
+    grep -q '<%= node['private_chef']['drbd']['device'] %> <%= node['private_chef']['drbd']['data_dir'] %> ' /proc/mounts
+}
+
 # 10 * SVWAIT
 try=300
 
@@ -42,8 +46,7 @@ case $ACTION in
     done
     ;;
   mounted)
-    DRBD_STATUS=$(cat /proc/drbd | egrep cs:)
-    if [[ "$DRBD_STATUS" =~ "cs:Connected ro:Primary/Secondary ds:UpToDate/UpToDate" ]]; then
+    if is_drbd_mounted; then
       echo "[OK] DRDB mounted on this machine"
       exit 0
     else

--- a/files/private-chef-cookbooks/chef-ha-drbd/templates/default/ha_backend_storage_drbd.erb
+++ b/files/private-chef-cookbooks/chef-ha-drbd/templates/default/ha_backend_storage_drbd.erb
@@ -41,6 +41,16 @@ case $ACTION in
       sleep 1
     done
     ;;
+  mounted)
+    DRBD_STATUS=$(cat /proc/drbd | egrep cs:)
+    if [[ "$DRBD_STATUS" =~ "cs:Connected ro:Primary/Secondary ds:UpToDate/UpToDate" ]]; then
+      echo "[OK] DRDB mounted on this machine"
+      exit 0
+    else
+      echo "[ERROR] DRDB not mounted on this machine ($DRDB_STATUS)"
+      exit 1
+    end
+    ;;
   status)
     STATUS=0 # exit status
     CURRENT_STATE="$2"

--- a/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
@@ -4,6 +4,8 @@
 #
 # All Rights Reserved
 
+include_recipe "private-chef::runit_setup"
+
 cookbook_migration = "/opt/opscode/embedded/bin/cookbook_migration.sh"
 
 checksum_path = node['private_chef']['opscode-chef']['checksum_path']

--- a/files/private-chef-cookbooks/private-chef/recipes/keepalived.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/keepalived.rb
@@ -5,6 +5,8 @@
 # All Rights Reserved
 #
 
+include_recipe "private-chef::runit_setup"
+
 keepalived_dir = node['private_chef']['keepalived']['dir']
 keepalived_etc_dir = File.join(keepalived_dir, "etc")
 keepalived_bin_dir = File.join(keepalived_dir, "bin")

--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-expander.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-expander.rb
@@ -5,6 +5,8 @@
 # All Rights Reserved
 #
 
+include_recipe "private-chef::runit_setup"
+
 expander_dir = node['private_chef']['opscode-expander']['dir']
 expander_etc_dir = File.join(expander_dir, "etc")
 expander_log_dir = node['private_chef']['opscode-expander']['log_directory']

--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -6,6 +6,8 @@
 # All Rights Reserved
 #
 
+include_recipe "private-chef::runit_setup"
+
 solr_dir              = node['private_chef']['opscode-solr4']['dir']            # /var/opt/opscode/opscode-solr4
 solr_data_dir         = node['private_chef']['opscode-solr4']['data_dir']       # /var/opt/opscpde/opscode-solr4/data
 solr_data_dir_symlink = File.join(solr_dir, "data")                             # /var/opt/opscode/opscode-solr4/data

--- a/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -17,6 +17,7 @@
 #
 
 include_recipe "private-chef::old_postgres_cleanup"
+include_recipe "private-chef::runit_setup"
 
 postgresql_dir = node['private_chef']['postgresql']['dir']
 postgresql_data_dir = node['private_chef']['postgresql']['data_dir']

--- a/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+include_recipe "private-chef::runit_setup"
+
 rabbitmq = node["private_chef"]["rabbitmq"]
 
 rabbitmq_dir = rabbitmq['dir']

--- a/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include_recipe "private-chef::runit_setup"
+
 redis = node['private_chef']['redis_lb']
 redis_dir = redis['dir']
 redis_etc_dir = File.join(redis_dir, "etc")

--- a/files/private-chef-cookbooks/private-chef/recipes/runit_setup.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/runit_setup.rb
@@ -1,0 +1,25 @@
+#
+# Author:: Jess Mink (<jmink@chef.io>)
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sv_lib_location = '/opt/opscode/bin/sv_lib'
+template sv_lib_location do
+  source "sv_lib.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+end

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-bookshelf-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-bookshelf-run.erb
@@ -1,4 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 exec 2>&1
+
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
 
 exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME=<%= node['private_chef']['bookshelf']['dir'] %> /opt/opscode/embedded/service/bookshelf/bin/bookshelf runit

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-keepalived-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-keepalived-run.erb
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 exec 2>&1
+
 exec chpst -P /opt/opscode/embedded/sbin/keepalived --log-console --log-detail --dump-conf --dont-fork --use-file=<%= File.join(node["private_chef"]["keepalived"]["dir"], "etc", "keepalived.conf") %>

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-expander-reindexer-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-expander-reindexer-run.erb
@@ -1,4 +1,11 @@
-#!/bin/sh
+#!/bin/bash
+
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
 
 /opt/opscode/bin/wait-for-rabbit
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-expander-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-expander-run.erb
@@ -1,4 +1,13 @@
-#!/bin/sh
+#!/bin/bash
+
+exec 2>&1
+
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
 
 /opt/opscode/bin/wait-for-rabbit
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-solr4-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-solr4-run.erb
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+
+exec 2>&1
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
 
 /opt/opscode/bin/wait-for-rabbit
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-postgresql-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-postgresql-run.erb
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 exec 2>&1
+
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
 exec chpst -P -U <%= node['private_chef']['postgresql']['username'] %> -u <%= node['private_chef']['postgresql']['username'] %> /opt/opscode/embedded/bin/postgres -D <%= node['private_chef']['postgresql']['data_dir'] %>
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-rabbitmq-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-rabbitmq-run.erb
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 exec 2>&1
+
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
 exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /usr/bin/env HOME=<%= node['private_chef']['rabbitmq']['dir'] %> /opt/opscode/embedded/bin/rabbitmq-server
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv-redis_lb-run.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv-redis_lb-run.erb
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 exec 2>&1
+
+source 'sv_lib'
+
+ensure_backing_storage
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
 exec chpst -P -o 131071 -u <%= node["private_chef"]["user"]["username"] %> -U <%= node["private_chef"]["user"]["username"] %> -o 100000 env HOME="<%= node["private_chef"]["redis_lb"]["dir"] %>" /opt/opscode/embedded/bin/redis-server <%= File.join(node["private_chef"]["redis_lb"]["dir"], "etc", "redis.conf") %>
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/sv_lib.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/sv_lib.erb
@@ -1,0 +1,23 @@
+# This file includes functions for use in the runit (sv-*) scripts
+
+# Backend services in an HA setup need to wait until the backing storage is mounted
+# @returns 0 if all required backing stores are mounted and 1 otherwise
+function ensure_backing_storage {
+  # If this isn't an HA situation there is no backing storage to wait for
+  if [[ '<%= node['private_chef']['topology'] %>' != 'ha' ]]; then
+    return 0
+  fi
+
+  echo "Ensuring backing datastore is mounted"
+  for attempt in {1..15}; do
+    <%= node['private_chef']['keepalived']['dir'] %>/bin/ha_backend_storage mounted
+    if [[ $? == 0 ]]; then
+      return 0
+    fi
+    echo "Backing datastore not yet mounted...."
+    sleep $((2 * attempt))
+  done
+
+  echo "Timed out waiting for storage (aws, drdb, etc) to mount.  Check your backing storage setup and try again"
+  return 1
+}


### PR DESCRIPTION
Background info here: https://chef.leankit.com/Boards/View/111432846/146112858

In short the backend services have historically tried to start before the HA backing store was mounted and then got horribly confused.  This prevents the backend ha services from starting until the backing datastore is mounted and passing basic tests.

It relies on the `ha_backend_storage status` command and is therefore backing storage level agnostic.

I tested it by hand on standalone (ensuring it built correctly and pedant passed) and with HA on EC2 (ebs) in which I ensured the services started correctly (with pedant tests passing) and then changed the backend storage status script to return 1 and saw that the services were waiting.

Wilson run: http://wilson.ci.opscode.us/job/chef-server-12-trigger-ad_hoc/231/