### PR TITLE
Disable jmxremote

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -124,7 +124,6 @@ node.default['private_chef']['opscode-solr4']['command'] =  "java -Xmx#{solr_mem
 node.default['private_chef']['opscode-solr4']['command'] << "#{java_opts}"
 # Enable GC Logging (very useful for debugging issues)
 node.default['private_chef']['opscode-solr4']['command'] << " -Xloggc:#{File.join(solr_log_dir, "gclog.log")} -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintTenuringDistribution"
-node.default['private_chef']['opscode-solr4']['command'] << " -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8086 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 node.default['private_chef']['opscode-solr4']['command'] << " -Dsolr.data.dir=#{solr_data_dir}"
 node.default['private_chef']['opscode-solr4']['command'] << " -Dsolr.solr.home=#{solr_home_dir}"
 node.default['private_chef']['opscode-solr4']['command'] << " -server"


### PR DESCRIPTION
This commit removes jmxremote which previously could have allowed anybody with access to the machine to load any class that they wished.  Resolves https://github.com/opscode/opscode-omnibus/issues/648.  Users can re-enable via `chef-server.rb` configuration change:

```ruby
opscode_solr4['java_opts'] = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8086 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false'
```