### PR TITLE
Bump chef-gem to 12.0.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,29 @@
   `:off`.
 * Ensure shell metacharacters in arguments to chef-server-ctl user-
   and org- commands are properly handled.
+* Pull in chef-client 12.0.3.
+* Update rabbitmq cookbook to be compatible with modern chef-client.
+* Update pivotal and knife-ec-backup knife configs to be compatible with modern chef-client.
+* Use chef-client -z instead of chef-solo in the server.
 
 ### oc\_erchef 1.3.1
 * Add incubation feature for policyfiles. Feature flag off by default.
 
 ### oc\_erchef 1.2.2
-* Add `s3_url_expiry_window_size` setting for s3 URL caching
+* Add `s3_url_expiry_window_size` setting for s3 URL caching.
+
+### omnibus-ctl 0.3.2
+* Use chef-client -z instead of chef-solo.
+* Reference chef-client via base_path.
+
+### knife-ec-backup 2.0.1
+* Added keys table / key rotation support.
+
+### ruby 2.1.4
+* Needed for ohai >= 2.
+
+### chef-gem 12.0.3
+* [chef-client 12 changelog](https://docs.chef.io/release_notes.html#what-s-new).
 
 ## 12.0.3 (2015-02-04)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,15 @@
 * oc\_erchef
   * Add incubation feature for policyfiles. Feature flag off by default.
 
+* knife-ec-backup
+  * Key rotation support.
+
+* Chef 12.0.3
+  * Chef 12.0.3 was vendored into the server.
+
+* Ruby 2.1.4
+  * Ruby 2.1.4 was vendored into the server.
+
 ## 12.0.3 (2015-02-04)
 
 ### What's New:

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -31,7 +31,7 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
 override :ruby, version: "2.1.4"
-override :'omnibus-ctl', version: "0.3.1"
+override :'omnibus-ctl', version: "0.3.2"
 override :'chef-gem', version: "12.0.3"
 
 # creates required build directories

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -31,7 +31,7 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
 override :'omnibus-ctl', version: "0.3.1"
-override :'chef-gem', version: "11.18.0"
+override :'chef-gem', version: "12.0.3"
 
 # creates required build directories
 dependency "preparation"

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -30,6 +30,7 @@ override :rebar, version: "2.0.0"
 override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
+override :ruby, version: "2.1.4"
 override :'omnibus-ctl', version: "0.3.1"
 override :'chef-gem', version: "12.0.3"
 

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -38,7 +38,7 @@ override :'chef-gem', version: "12.0.3"
 dependency "preparation"
 
 # global
-dependency "chef-gem" # for embedded chef-solo
+dependency "chef-gem" # for embedded chef-client -z runs
 dependency "private-chef-scripts" # assorted scripts used by installed instance
 dependency "private-chef-ctl" # additional project-specific private-chef-ctl subcommands
 dependency "ctl-man" # install man page

--- a/config/software/knife-ec-backup-gem.rb
+++ b/config/software/knife-ec-backup-gem.rb
@@ -15,7 +15,7 @@
 #
 
 name "knife-ec-backup"
-default_version "2.0.0.beta.2"
+default_version "2.0.1"
 
 dependency "pg-gem"
 dependency "sequel-gem"

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -105,6 +105,7 @@ default['private_chef']['rabbitmq']['node_port'] = '5672'
 default['private_chef']['rabbitmq']['nodename'] = 'rabbit@localhost'
 default['private_chef']['rabbitmq']['vip'] = '127.0.0.1'
 default['private_chef']['rabbitmq']['consumer_id'] = 'hotsauce'
+default['private_chef']['rabbitmq']['env_path'] = "/opt/opscode/bin:/opt/opscode/embedded/bin:/usr/bin:/bin"
 
 ####
 # Jetty dummy for logs

--- a/files/private-chef-cookbooks/private-chef/recipes/add_ons_wrapper.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/add_ons_wrapper.rb
@@ -42,8 +42,9 @@ node['private_chef']['addons']['packages'].each do |pkg|
   end
 end
 
-if (node['private_chef']['addons']['path'])
-  include_recipe "private-chef::add_ons_local"
-else
+# chef-solo and chef-client -z return different things :(
+if (node['private_chef']['addons']['path'] == nil) || (node['private_chef']['addons']['path'] == {})
   include_recipe "private-chef::add_ons_remote"
+else
+  include_recipe "private-chef::add_ons_local"
 end

--- a/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
@@ -2,3 +2,4 @@ node_name "pivotal"
 chef_server_url "<%= @prefix %>://<%= @vip %>"
 chef_server_root "<%= @prefix %>://<%= @vip %>"
 client_key "/etc/opscode/pivotal.pem"
+ssl_verify_mode :verify_none

--- a/files/private-chef-ctl-commands/cleanup.rb
+++ b/files/private-chef-ctl-commands/cleanup.rb
@@ -5,7 +5,7 @@ add_command_under_category "cleanup", "general", "Perform post-upgrade removal o
   use_why_run_mode = ARGV.include?("--no-op")
 
   # Our cleanup process is really just a special chef run
-  command = ["chef-solo",
+  command = ["chef-client -z",
              "--config #{base_path}/embedded/cookbooks/solo.rb",
              "--json-attributes #{base_path}/embedded/cookbooks/post_upgrade_cleanup.json",
              "--log_level fatal"] # yes, that's an underscore in log_level

--- a/files/private-chef-ctl-commands/install.rb
+++ b/files/private-chef-ctl-commands/install.rb
@@ -18,7 +18,7 @@ add_command_under_category "install", "general", "Install addon package by name,
   end
 
   attributes_path = "#{base_path}/embedded/cookbooks/install_params.json"
-  command = ["chef-solo",
+  command = ["chef-client -z",
     "--config #{base_path}/embedded/cookbooks/solo.rb",
     "--json-attributes #{attributes_path}",
     "--log_level fatal"]

--- a/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
+++ b/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
@@ -500,6 +500,7 @@ EOF
     chef_server_root '#{@options.chef12_server_url}'
     node_name 'pivotal'
     client_key '/etc/opscode/pivotal.pem'
+    ssl_verify_mode :verify_none
     EOH
 
     log "Writing knife-ec-backup config to /tmp/knife-ec-backup-config.rb"


### PR DESCRIPTION
Related:
+ ~~https://github.com/opscode/omnibus-ctl/pull/23~~

TODO:
- [x] Test that knife-opc dependent cmds work with ruby 2.0.
- [x] Test upgrade from open source as that uses knife-ec-backup.
- [x]  On reconfigure: `[2015-01-16T22:29:26+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/opscode/embedded/cookbooks/local-mode-cache`
- [x] Test `chef-server-ctl install`
- [x] Test `chef-server-ctl cleanup`
- [x] Fix cache warning
- [x] Update `omnibus-ctl` after https://github.com/opscode/omnibus-ctl/pull/23 merges
- [x] Changelog