### PR TITLE
Mp/multiple keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 12.0.2 (unreleased)
 
+
 ### opscode-omnibus
 * Added key management and rotation commands add-client-key,
   add-user-key, delete-user-key, delete-client-key, list-client-keys,
@@ -12,13 +13,17 @@
 * Ensure nginx restarts on frontends after lua-related changes
 * Updated nginx's logrotate config with proper log ownership.
 
+### oc\_erchef 1.2.0
+* add basic multikey/key rotation support. THis is not yet exposed via
+  API, but is being used within `oc_erchef` itself.
+
 ### oc\_erchef 1.1.1
 * Updated `sqerl` version to pull in more current `epgsql` dependency
 * Pulled repos `chef_db`, `chef_index`, `chef_objects`, `depsolver`, `oc_chef_authz`, and `oc_chef_wm` into apps in `oc_erchef`.
 * Pulled `chef_wm` into `oc_chef_wm`.
 * Updated integration tests, and got integration and unit tests
   running in Travis CI.
-* Remove array merging in chef_deep_merge, fixing incorrect search
+* Remove array merging in `chef_deep_merge`, fixing incorrect search
   results for arrays.
 
 ### opscode-chef-mover 2.2.19

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,11 +10,15 @@
 * chef-server-ctl
   * Added key management and rotation commands add-client-key,
     add-user-key, delete-user-key, delete-client-key,
-    list-client-keys, and list-user-keys.
+    list-client-keys, and list-user-keys.  This is considered a beta
+    feature at this time.
 
-* oc_erchef
+* oc\_erchef
   * BUG FIX: Search results for arrays previously would match values
     from all precedence levels.
+  * Preliminary internal support for multiple key authentication and key
+    rotation. API support will follow in a subsequent release. This is
+    considered a beta feature at this time.
 
 ## 12.0.1 (2014-12-17)
 

--- a/config/software/enterprise-chef-server-schema.rb
+++ b/config/software/enterprise-chef-server-schema.rb
@@ -15,7 +15,7 @@
 #
 
 name "enterprise-chef-server-schema"
-default_version "2.5.1"
+default_version "2.5.3"
 
 source git: "git@github.com:opscode/enterprise-chef-server-schema.git"
 

--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -15,7 +15,7 @@
 #
 
 name "oc-chef-pedant"
-default_version "1.0.69"
+default_version "1.0.71"
 
 source git: "git@github.com:opscode/oc-chef-pedant.git"
 

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -15,7 +15,7 @@
 #
 
 name "oc_erchef"
-default_version "1.1.2"
+default_version "1.2.0"
 
 source git: "git@github.com:opscode/oc_erchef"
 

--- a/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -3,7 +3,7 @@ define_upgrade do
     must_be_data_master
     run_command("make deploy",
                 :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema",
-                :env => {"EC_TARGET" => "@2.5.1", "OSC_TARGET" => "@1.0.4", "DB_USER" => Partybus.config.database_unix_user}
+                :env => {"EC_TARGET" => "@2.5.2", "OSC_TARGET" => "@1.0.4", "DB_USER" => Partybus.config.database_unix_user}
                 )
     run_command("sudo -u #{Partybus.config.database_unix_user} /opt/opscode/embedded/bin/psql opscode_chef -c 'select migrate_keys();'")
   end

--- a/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -3,7 +3,7 @@ define_upgrade do
     must_be_data_master
     run_command("make deploy",
                 :cwd => "/opt/opscode/embedded/service/enterprise-chef-server-schema",
-                :env => {"EC_TARGET" => "@2.5.2", "OSC_TARGET" => "@1.0.4", "DB_USER" => Partybus.config.database_unix_user}
+                :env => {"EC_TARGET" => "@2.5.3", "OSC_TARGET" => "@1.0.4", "DB_USER" => Partybus.config.database_unix_user}
                 )
     run_command("sudo -u #{Partybus.config.database_unix_user} /opt/opscode/embedded/bin/psql opscode_chef -c 'select migrate_keys();'")
   end


### PR DESCRIPTION
This pulls in all the updated components for initial support of multiple keys for clients and users. 

ping @chef/lob

CI: http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/303/downstreambuildview/

Pending another run of oc_erchef through travis before it can be merged, but otherwise no changes expected. 
Edit: second travis run was green, seems to have been some temporary trouble with gems. 