### PR TITLE
Reset intialization_options in FileVendor after a chef_run

### DIFF
--- a/files/private-chef-cookbooks/private-chef/libraries/chef_run_provider.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/chef_run_provider.rb
@@ -11,6 +11,7 @@ class Chef
           mutate_chef_config
           converge
           Chef::Config.restore(old_config)
+          Chef::Cookbook::FileVendor.instance_variable_set(:@initialization_options, Chef::Config[:cookbook_path])
         end
       end
 


### PR DESCRIPTION
When fetching a template from a cookbook, Chef will create a
Chef::Cookbook::FileVendor object via the
FileVendor.create_from_manifest function.  This function constructs a
new vendor object, sending the the manifest and the class instance
variable @initialization_options to the constructor.

Since @initialization_options is an instance variable of the class
object, it is shared between calls to create_from_manifest.  It is set
in the FileVendor.fetch_from_disk method.  If fetch_from_disk is first
called when we are inside a plugin, it will carry the plugin's
cookbook path into the main run, causing failures when attempting to
download templates.