### PR TITLE
oc-chef-pedant to 1.0.72

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -15,7 +15,7 @@
 #
 
 name "oc-chef-pedant"
-default_version "1.0.71"
+default_version "1.0.72"
 
 source git: "git@github.com:opscode/oc-chef-pedant.git"
 


### PR DESCRIPTION
Removes test focus. Passes build: 

http://wilson.ci.chef.co/job/chef-server-12-test/552/architecture=x86_64,platform=ubuntu-11.04,project=chef-server,role=tester/

