### PR TITLE
Backport oc-id application config to EC11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Enterprise Chef Changelog
 
-## 11.2.8 (Unreleased)
+## 11.2.7 (Unreleased)
 
 * Ensure nginx restarts on frontends after lua-related changes
+* Backport the export of oc-id analytics configuration information in `actions-source.json`
 
 ## 11.2.6 (2014-12-17)
 * Add an OmnibusHelper method to provide an owner and group hash
@@ -20,7 +21,7 @@
 ## 11.2.5 (2013-11-03)
 
 ### oc_erchef
-* Upgrade to 0.28.3 and then revert to 0.25.14.2 for addon compatibility.  The issue was that changing the darklaunch default from couchdb to postgresql changes behavior for addons that don't go through the external LB.  Once the addons have been upgraded to respect the full darklaunch flagset we'll be able to upgrade oc_erchef. 
+* Upgrade to 0.28.3 and then revert to 0.25.14.2 for addon compatibility.  The issue was that changing the darklaunch default from couchdb to postgresql changes behavior for addons that don't go through the external LB.  Once the addons have been upgraded to respect the full darklaunch flagset we'll be able to upgrade oc_erchef.
 
 ### oc-chef-pedant
 * Upgrade to 1.0.62, but revert to 1.0.29.5 for addon compatibility

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,21 @@
 # Enterprise Chef Release Notes
 
-## 11.2.6 (Unreleased)
+## 11.2.8 (unreleased)
+
+### What's New
+
+### Bug Fixes:
+
+The following items are new for Enterprise Chef 11.2.8 and/or are
+changes from previous versions:
+
+* Support the use of Chef Analytics 1.1 with Enterprise Chef 11
+
+The following items are the set of bug fixes that have been applied since Enterprise Chef 11.2.6:
+
+* Ensure nginx restarts on frontends after lua-related changes
+
+## 11.2.6 (2014-12-17)
 
 ### What's New
 
@@ -11,7 +26,7 @@ changes from previous versions:
 
 * [OC-11712] Adjust perms to 0750 for all service's log dirs
 
-The following items are the set of bug fixes that have been applied since Enterprise Chef 11.2.6:
+The following items are the set of bug fixes that have been applied since Enterprise Chef 11.2.5:
 
 
 ## 11.2.5 (2014-11-03)
@@ -31,7 +46,7 @@ The following items are the set of bug fixes that have been applied since Enterp
 
 * [OC-11769] make oc_chef_authz a tunable in private-chef.rb
 * Fix oc_chef_authz timeout tunable
-* The 'gather-logs' script now obeys the attribute for postsgresql['username'] 
+* The 'gather-logs' script now obeys the attribute for postgresql['username']
 * oc_erchef 0.25.14.2 - Reverting to previous version for addon compatibility
 
 ## 11.2.4 (Never Released)

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -472,6 +472,22 @@ default['private_chef']['oc_id']['db_pool_size'] = '20'
 
 default['private_chef']['oc_id']['administrators'] = []
 
+# Use to define predefined applications that can authenticate with the server.
+# Entries are a hash with the key being the name of the application and the
+# value being a hash with a 'redirect_uri' key. Example:
+#
+#     oc_id['applications'] = {
+#       'supermarket' => {
+#         'redirect_uri' => 'http://supermarket.mycorp/auth/chef_oauth2/callback'
+#       },
+#       'another_app' => {
+#         'redirect_uri' => 'http://anotherapp.mycorp/auth/chef_oauth2/callback'
+#       }
+#     }
+#
+# Default value: `{}`.
+default['private_chef']['oc_id']['applications'] = {}
+
 ###
 # Dark Launch
 ###

--- a/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_provider.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_provider.rb
@@ -1,0 +1,47 @@
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class OcIdApplication < Chef::Provider::LWRPBase
+      include Chef::Mixin::ShellOut
+
+      use_inline_resources if defined?(:use_inlined_resources)
+
+      action :create do
+        converge_by "create oc-id application '#{new_resource.name}'" do
+          attributes = create!
+
+          directory '/etc/opscode/oc-id-applications' do
+            owner 'root'
+            group 'root'
+            mode '0755'
+          end
+
+          file "/etc/opscode/oc-id-applications/#{new_resource.name}.json" do
+            content Chef::JSONCompat.to_json_pretty(attributes)
+            owner 'root'
+            group 'root'
+            mode '0600'
+          end
+        end
+      end
+
+      private
+
+      def create!
+        @attributes ||= Chef::JSONCompat.from_json(command("
+          app = Doorkeeper::Application.find_or_create_by(\
+            :name => \"#{new_resource.name}\");\
+          app.update_attributes(\
+            :redirect_uri => \"#{new_resource.redirect_uri}\");\
+          puts app.to_json
+          ")).delete_if { |key| %w[ id created_at updated_at].include? key }
+      end
+
+      def command(text)
+        shell_out!("bin/rails runner -e production '#{text}'",
+                   :cwd => '/opt/opscode/embedded/service/oc_id').stdout.chomp
+      end
+    end
+  end
+end

--- a/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_resource.rb
+++ b/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_resource.rb
@@ -1,0 +1,15 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class OcIdApplication < Chef::Resource::LWRPBase
+      self.resource_name = 'oc_id_application'
+
+      actions :create
+      default_action :create
+
+      attribute :name, :kind_of => String, :name_attribute => true
+      attribute :redirect_uri, :kind_of => String, :required => true
+    end
+  end
+end

--- a/files/private-chef-cookbooks/private-chef/recipes/actions.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/actions.rb
@@ -1,4 +1,15 @@
 if is_data_master?
+  # Contents of the OC ID app's JSON data, to be called later
+  oc_id_app = proc do
+    begin
+      Chef::JSONCompat.from_json(
+        open('/etc/opscode/oc-id-applications/analytics.json').read
+      )
+    rescue Errno::ENOENT
+      Chef::Log.warn('No analytics oc-id-application present. Skipping')
+      {}
+    end
+  end
 
   directory "/etc/opscode-analytics" do
     owner OmnibusHelper.new(node).ownership['owner']
@@ -20,18 +31,19 @@ if is_data_master?
   file "/etc/opscode-analytics/actions-source.json" do
     owner 'root'
     mode '0600'
-    content Chef::JSONCompat.to_json_pretty({
-      private_chef: {
-        api_fqdn:           node['private_chef']['lb']['api_fqdn'],
-        rabbitmq_host:      node['private_chef']['rabbitmq']['vip'],
-        rabbitmq_port:      node['private_chef']['rabbitmq']['node_port'],
-        rabbitmq_vhost:     node['private_chef']['rabbitmq']['actions_vhost'],
-        rabbitmq_exchange:  node['private_chef']['rabbitmq']['actions_exchange'],
-        rabbitmq_user:      node['private_chef']['rabbitmq']['actions_user'],
-        rabbitmq_password:  node['private_chef']['rabbitmq']['actions_password']
-      }
-    })
+    content lazy {
+      Chef::JSONCompat.to_json_pretty(
+        private_chef: {
+          api_fqdn:           node['private_chef']['lb']['api_fqdn'],
+          oc_id_application:  oc_id_app.call,
+          rabbitmq_host:      node['private_chef']['rabbitmq']['vip'],
+          rabbitmq_port:      node['private_chef']['rabbitmq']['node_port'],
+          rabbitmq_vhost:     node['private_chef']['rabbitmq']['actions_vhost'],
+          rabbitmq_exchange:  node['private_chef']['rabbitmq']['actions_exchange'],
+          rabbitmq_user:      node['private_chef']['rabbitmq']['actions_user'],
+          rabbitmq_password:  node['private_chef']['rabbitmq']['actions_password']
+        }
+      )
+    }
   end
-
-
 end

--- a/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -109,7 +109,19 @@ execute "oc_id_schema" do
   command "bundle exec rake db:migrate"
   path ["/opt/opscode/embedded/bin"]
   cwd "/opt/opscode/embedded/service/oc_id"
-  environment({"RAILS_ENV" => "production"})
+
+  # There are other recipes that depend on having a VERSION environment
+  # variable. If that environment variable is set when we run `rake db:migrate`,
+  # and it is set to something the the migrations do not expect, this will
+  # break.
+  #
+  # We want to migrate to the latest version, which we can get by looking at the
+  # date prefix of the latest file in the db/migrate directory.
+  #
+  # Also set the RAILS_ENV as is needed.
+  environment("RAILS_ENV" => "production",
+              "VERSION" => `ls -1 /opt/opscode/embedded/service/oc_id/db/migrate | tail -n 1 | sed -e "s/_.*//g"`.chomp)
+
   only_if { is_data_master? }
 end
 
@@ -120,6 +132,15 @@ end
 if node['private_chef']['bootstrap']['enable']
   execute "/opt/opscode/bin/private-chef-ctl start oc_id" do
     retries 20
+  end
+end
+
+# Take the existing oc_id.applications (with only a redirect_uri), ensure they
+# exist in the database, and dump their data to /etc/opscode/oc-id-applications.
+node['private_chef']['oc_id']['applications'].each do |name, app|
+  oc_id_application name do
+    redirect_uri app['redirect_uri']
+    only_if { is_data_master? }
   end
 end
 


### PR DESCRIPTION
This patch backports the code from CS12 which exports oc-id configuration for Chef analytics via the `actions-source.json` file

Tested with a full run of `private-chef-ctl test --all` and built via CI.  Analytics can accept all action messages outputted by Erchef.

Successful build on CI : http://wilson.ci.chef.co/view/Private%20Chef/job/private-chef-build/788/