### PR TITLE
Expose keygen_cache configurables in chef-server.rb

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -196,6 +196,11 @@ default['private_chef']['opscode-erchef']['depsolver_worker_count'] = 5
 default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['max_request_size'] = 1000000
 default['private_chef']['opscode-erchef']['cleanup_batch_size'] = 0
+default['private_chef']['opscode-erchef']['keygen_cache_size'] = 10
+default['private_chef']['opscode-erchef']['keygen_start_size'] = 0
+default['private_chef']['opscode-erchef']['keygen_cache_workers'] = :auto
+default['private_chef']['opscode-erchef']['keygen_timeout'] = 1000
+default['private_chef']['opscode-erchef']['keygen_key_size'] = 2048
 
 ###
 # Legacy path (required for cookbok migration)

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -111,7 +111,14 @@
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>}
             ]},
   {chef_authn, [
-                {keyring, [{default, "/etc/opscode/webui_pub.pem"}]}
+                {keyring, [{default, "/etc/opscode/webui_pub.pem"}]},
+                <% unless node['private_chef']['opscode-erchef']['keygen_cache_workers'] == :auto -%>
+                {keygen_cache_workers, <%= node['private_chef']['opscode-erchef']['keygen_cache_workers'] %>},
+                <% end -%>
+                {keygen_cache_size, <%= node['private_chef']['opscode-erchef']['keygen_cache_size'] %>},
+                {keygen_start_size, <%= node['private_chef']['opscode-erchef']['keygen_start_size'] %>},
+                {keygen_timeout, <%= node['private_chef']['opscode-erchef']['keygen_timeout'] %>},
+                {keygen_size, <%= node['private_chef']['opscode-erchef']['keygen_key_size'] %>}
                ]},
   {oc_chef_authz, [
                 {authz_root_url, "http://<%= @helper.vip_for_uri('oc_bifrost') %>:<%= node['private_chef']['oc_bifrost']['port'] %>" },


### PR DESCRIPTION
The keygen_cache in chef_authn provides performance-relevant
configuration options.  We likely need to customize these in some
installations, such as are slimmed down test nodes.