### PR TITLE
Update backports to 3.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     addressable (2.3.6)
     arr-pm (0.0.9)
       cabin (> 0)
-    backports (3.6.0)
+    backports (3.6.4)
     cabin (0.6.1)
     chef-sugar (1.3.0)
     childprocess (0.5.3)


### PR DESCRIPTION
This fixes the following error when FPM attempts to create a package:

```
/home/jenkins/workspace/private-chef-build/architecture/x86_64/platform/ubuntu-12.04/project/private-chef/role/builder/vendor/bundle/ruby/2.1.0/gems/backports-3.6.0/lib/backports/1.9.1/io/open.rb:2:in `close': Bad file descriptor @ fptr_finalize - /home/jenkins/workspace/private-chef-build/architecture/x86_64/platform/ubuntu-12.04/project/private-chef/role/builder/vendor/bundle/ruby/2.1.0/gems/backports-3.6.0/lib/backports/1.9.1/io/open.rb (Errno::EBADF)
```

Test CI run:
http://wilson.ci.chef.co/job/private-chef-trigger-ad_hoc/284/downstreambuildview/

/cc @chef/lob 