### PR TITLE
Update omnibus and omnibus software:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,18 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 2e26be554787803214ba9525b6b4214b5c7b6d43
+  revision: a6e79574667c86724024a04e665c809441773fb3
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: ed0e77e06ecc6adf24436f6d2e940ad9b5032262
+  revision: 0748385503cbd98376060ecd7daa5d1e761d7de3
   specs:
     omnibus (4.0.0)
       chef-sugar (~> 2.2)
       cleanroom (~> 1.0)
       mixlib-shellout (~> 1.4)
+      mixlib-versioning
       ohai (~> 7.2)
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
@@ -22,8 +23,8 @@ GEM
   specs:
     chef-sugar (2.5.0)
     cleanroom (1.0.0)
-    ffi (1.9.6)
-    ffi-yajl (1.3.1)
+    ffi (1.9.8)
+    ffi-yajl (1.4.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.2)
     ipaddress (0.8.0)
@@ -33,6 +34,7 @@ GEM
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
     mixlib-shellout (1.6.1)
+    mixlib-versioning (1.0.0)
     ohai (7.4.1)
       ffi (~> 1.9)
       ffi-yajl (~> 1.1)

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -31,8 +31,8 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
 override :ruby, version: "2.1.4"
-override :'omnibus-ctl', version: "0.3.2"
 override :'chef-gem', version: "12.0.3"
+override :'server-jre', version: "7u25"
 
 # creates required build directories
 dependency "preparation"

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -11,7 +11,6 @@ s3_bucket      'opscode-omnibus-cache'
 
 # Customize compiler bits
 # ------------------------------
-solaris_compiler 'gcc'
 build_retries 3
 fetcher_read_timeout 120
 


### PR DESCRIPTION
- Pull in latest omnibus to move away from git-based versioning
- Update omnibus-software for compatibility with new omnibus

This commit bumps omnibus-ctl to 0.3.3 which fixes a small
bug in the log tail command.