### PR TITLE
Move to using a static version number

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -22,7 +22,8 @@ package_name    "chef-server-core"
 replace         "private-chef"
 conflict        "private-chef"
 install_dir     "/opt/opscode"
-build_version   Omnibus::BuildVersion.new.semver
+# last released version is 12.0.5
+build_version   "12.0.6"
 build_iteration 1
 
 override :cacerts, version: '2014.08.20'


### PR DESCRIPTION
Using a static version will make it easier to promote binary
artifacts. However, it comes with the cost of having to managing
bumping the version as part of the normal development cycle.