### PR TITLE
server api versioning

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -16,7 +16,8 @@
 
 name "oc-chef-pedant"
 
-default_version "2.0.2"
+#default_version "2.0.3"
+default_version "mp/server-api-versioning"
 
 source git: "git@github.com:opscode/oc-chef-pedant.git"
 

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -16,7 +16,8 @@
 
 name "oc_erchef"
 
-default_version "1.6.3"
+#default_version "1.6.5"
+default_version "mp/server-api-versioning"
 
 source git: "git@github.com:opscode/oc_erchef"
 

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
@@ -47,6 +47,7 @@ local p_org_base = P"/organizations"
 local p_auth_user = P"authenticate_user"
 local p_system_recovery = P"system_recovery"
 local p_license = P"license"
+local p_api_version = P"server_api_version"
 local p_acl = P"/_acl"
 local p_search = P"search"
 local p_nodes = P"nodes"
@@ -138,12 +139,14 @@ local p_keys_route = ((p_named_org_prefix * p_clients * p_sep * p_identifier * C
 
 
 local p_license_route = (p_sep * Cendpoint(p_license) * p_trailing_sep)
+local p_server_api_version_route = (p_sep * Cendpoint(p_api_version) * p_trailing_sep)
 
 -- Everything that gets sent to erchef
 local p_erchef = p_keys_route +
                  (p_named_org_prefix * p_erchef_direct) +
                  p_erchef_users +
-                 p_license_route
+                 p_license_route +
+                 p_server_api_version_route
 
 -- erchef routing rules for chef_internal, which includes an additional
 -- principals endpoint not exposed via the api rules

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -204,7 +204,7 @@
                        {file, "<%= File.join(@log_directory, 'requests.log') %>"},
                        {file_size, <%= (@log_rotation['file_maxbytes'].to_f/1024/1024).round %>},  %% Size in MB
                        {files, <%= @log_rotation['num_to_keep'] %>},
-                       {annotations, [req_id, org_name, msg, darklaunch, perf_stats, user]}
+                       {annotations, [req_id, org_name, msg, darklaunch, perf_stats, user, req_api_version]}
                        ]
                       }]}]
       },

--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -179,6 +179,9 @@ policies?                   <%= node['private_chef']['lb']['xdl_defaults']['poli
 
 old_runlists_and_search true
 
+# Default server api version for all requests that don't specify it.
+server_api_version      0
+
 <%- if @log_http_requests %>
 
 # Log HTTP Requests


### PR DESCRIPTION
* Bumped chef-pedant and oc_erchef. 
* ADded config entries to capture req_api_version to log 
* Added routing for /server_api_version 
* Added pedant config entry for req_api_version.  I may revisit this  to make that the default value configurable.
