### PR TITLE
update omnibus-software for openssl 1.0.1m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@
 * Adds policyfile validation support
 * License and readme updates
 
+### openssl 1.0.1m
+* CVE-2015-0286: Segmentation fault in ASN1_TYPE_cmp fix
+* CVE-2015-0287: ASN.1 structure reuse memory corruption fix
+* CVE-2015-0289: PKCS7 NULL pointer dereferences fix
+* CVE-2015-0293: DoS via reachable assert in SSLv2 servers fix
+* CVE-2015-0209: Use After Free following d2i_ECPrivatekey error fix
+* CVE-2015-0288: X509_to_X509_REQ NULL pointer deref fix
+
 ## 12.0.5 (2014-02-26)
 
 ### bookshelf 1.1.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 3774d79786d52530528ba97f30cbbfa08b32306a
+  revision: e5912a9c375c280219c4c5e9d4d8ed92547f2cc4
   specs:
     omnibus-software (4.0.0)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,15 @@ For specific breakdown of updated components, refer to CHANGELOG.md
   for Policfyile validation.  Policyfile is disabled by default, stay tuned for
   further updates in this space.
 
+### Security Updates
+
+* OpenSSL 1.0.1m - CVE-2015-0286: Segmentation fault in ASN1_TYPE_cmp fix
+* OpenSSL 1.0.1m - CVE-2015-0287: ASN.1 structure reuse memory corruption fix
+* OpenSSL 1.0.1m - CVE-2015-0289: PKCS7 NULL pointer dereferences fix
+* OpenSSL 1.0.1m - CVE-2015-0293: DoS via reachable assert in SSLv2 servers fix
+* OpenSSL 1.0.1m - CVE-2015-0209: Use After Free following d2i_ECPrivatekey error fix
+* OpenSSL 1.0.1m - CVE-2015-0288: X509_to_X509_REQ NULL pointer deref fix
+
 ## 12.0.5 (2014-02-26)
 
 ### What's New


### PR DESCRIPTION
For convenience, [here's](https://github.com/chef/omnibus-software/compare/3774d79786d52530528ba97f30cbbfa08b32306a...e5912a9c375c280219c4c5e9d4d8ed92547f2cc4) the diff for `omnibus-software`.