### PR TITLE
Update mover's oc_chef_authz config

### DIFF
--- a/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -50,13 +50,22 @@
   {oc_chef_authz, [
                 {authz_root_url, "http://<%= @helper.vip_for_uri('oc_bifrost') %>:<%= node['private_chef']['oc_bifrost']['port'] %>" },
                 {authz_service, [{root_url, "http://<%= @helper.vip_for_uri('oc_bifrost') %>:<%= node['private_chef']['oc_bifrost']['port'] %>" },
-                                 {timeout, 2000}]},
+                                 {timeout, <%= node['private_chef']['opscode-erchef']['authz_timeout'] %>},
+                                 {init_count, <%= node['private_chef']['oc_chef_authz']['http_init_count'] %>},
+                                 {max_count, <%= node['private_chef']['oc_chef_authz']['http_max_count'] %>},
+                                 {cull_interval, <%= node['private_chef']['oc_chef_authz']['http_cull_interval'] %>},
+                                 {max_age, <%= node['private_chef']['oc_chef_authz']['http_max_age'] %>},
+                                 {max_connection_duration, <%= node['private_chef']['oc_chef_authz']['http_max_connection_duration'] %>},
+                                 {ibrowse_options, <%= node['private_chef']['oc_chef_authz']['ibrowse_options'] %>}
+                                 ]},
                 %% COUCHDB REMOVE THESE
                 {couchdb_host, "127.0.0.1"},
-                {couchdb_port, 5984 },
+                {couchdb_port, 5987 },
                 %% END COUCHDB REMOVE THESE
-                {authz_superuser_id, <<"<%= node['private_chef']['oc_bifrost']['superuser_id'] %>">>}
+                {authz_superuser_id, <<"<%= node['private_chef']['oc_bifrost']['superuser_id'] %>">>},
+                {cleanup_batch_size, <%= node['private_chef']['opscode-erchef']['cleanup_batch_size'] %>}
                ]},
+
   {chef_db, [
              {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
              {cache_defaults, [{max_size, <%= @max_cache_size %> },


### PR DESCRIPTION
This is necessary for mover to create a pool of ibrowse workers to make
authz changes in a migration.

I wonder if we want to consider using partial templates for this kind of thing.