### PR TITLE
Convert chef-server-ctl key commands to use Chef::Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 12.1.0 (unknown)
 
+### chef-client master
+* Server's install of Chef now floats on master.
+
+### knife-opc master
+* Server's install of knife-opc now floats on master.
+
 ### oc-chef-pedant
 *  2.1.0
   * Versioned testing support for users, clients, and principals
@@ -14,6 +20,7 @@
 
 ### opscode-omnibus
 * Remove install message from postinst package script
+* Update chef-server-ctl key commands to use chef-client's Chef::Key object.
 
 ## 12.0.8 (2015-04-20)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 3039a4439971ab95e476d02f742bc12a6d0e2bd7
+  revision: 4ca326c4ea5dadbd32c700ff3c31cb8b63a9977b
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: 1bb13b23df23b03c20e7f5cb9db680014dc1aec0
+  revision: 09e418fb7f49f64586056610da4aa0993d4f937f
   specs:
     omnibus (4.0.0)
       chef-sugar (~> 3.0)

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -32,14 +32,13 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
 override :ruby, version: "2.1.4"
-override :'chef-gem', version: "12.0.3"
 override :'server-jre', version: "7u25"
 
 # creates required build directories
 dependency "preparation"
 
 # global
-dependency "chef-gem" # for embedded chef-client -z runs
+dependency "chef" # for embedded chef-client -z runs
 dependency "private-chef-scripts" # assorted scripts used by installed instance
 dependency "private-chef-ctl" # additional project-specific private-chef-ctl subcommands
 dependency "ctl-man" # install man page

--- a/config/software/knife-opc-gem.rb
+++ b/config/software/knife-opc-gem.rb
@@ -15,7 +15,7 @@
 #
 
 name "knife-opc"
-default_version "0.3.0"
+default_version "master"
 
 source git: "git://github.com/opscode/knife-opc.git"
 

--- a/files/private-chef-ctl-commands/Gemfile
+++ b/files/private-chef-ctl-commands/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 # Used for rspec testing only
 gem "rspec"
-gem "chef"
+gem "chef", github: 'chef/chef', :branch => 'master'
 gem 'omnibus-ctl', github: 'chef/omnibus-ctl', :branch => 'master'
 

--- a/files/private-chef-ctl-commands/Gemfile.lock
+++ b/files/private-chef-ctl-commands/Gemfile.lock
@@ -1,16 +1,10 @@
 GIT
-  remote: git://github.com/chef/omnibus-ctl.git
-  revision: 48b5bf8809a086848ab3933aa83e7750b4f5a0ef
+  remote: git://github.com/chef/chef.git
+  revision: 44d70ba0f1b38bc3e1170ae978ad5e9a11679df3
   branch: master
   specs:
-    omnibus-ctl (0.3.4)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    builder (3.2.2)
-    chef (12.2.1)
-      chef-zero (~> 4.0)
+    chef (12.4.0.dev.0)
+      chef-zero (~> 4.1)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
       ffi-yajl (>= 1.2, < 3.0)
@@ -31,7 +25,19 @@ GEM
       rspec_junit_formatter (~> 0.2.0)
       serverspec (~> 2.7)
       specinfra (~> 2.10)
-    chef-zero (4.2.0)
+
+GIT
+  remote: git://github.com/chef/omnibus-ctl.git
+  revision: 3f61f2e1af8b261743aad8dd767c1d4b0173a4d6
+  branch: master
+  specs:
+    omnibus-ctl (0.3.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    chef-zero (4.2.1)
       ffi-yajl (>= 1.1, < 3.0)
       hashie (~> 2.0)
       mixlib-log (~> 1.3)
@@ -41,11 +47,10 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     ffi (1.9.8)
-    ffi-yajl (2.0.0)
-      ffi (~> 1.5)
+    ffi-yajl (2.1.0)
       libyajl2 (~> 1.2)
     hashie (2.1.2)
-    highline (1.7.1)
+    highline (1.7.2)
     ipaddress (0.8.0)
     libyajl2 (1.2.0)
     method_source (0.8.2)
@@ -62,7 +67,7 @@ GEM
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    net-ssh-multi (1.2.0)
+    net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     ohai (8.2.0)
@@ -88,9 +93,9 @@ GEM
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.2)
+    rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    rspec-expectations (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-its (1.2.0)
@@ -104,13 +109,13 @@ GEM
       builder (< 4)
       rspec (>= 2, < 4)
       rspec-core (!= 2.12.0)
-    serverspec (2.14.0)
+    serverspec (2.14.1)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.25)
     slop (3.6.0)
-    specinfra (2.28.1)
+    specinfra (2.30.0)
       net-scp
       net-ssh
     systemu (2.6.5)
@@ -121,6 +126,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  chef
+  chef!
   omnibus-ctl!
   rspec


### PR DESCRIPTION
:warning: *THIS WILL FLOAT CHEF-CLIENT ON MASTER* :warning: 
+ Update `chef-server-ctl` key commands to use `Chef::Key` and support server-side key generation.
+ Float knife-opc on master.
+ Float chef-client on master (makes sense to do now, since I need functionality from master I just added).

Depends on:
+ https://github.com/chef/omnibus-software/pull/403
+ https://github.com/chef/omnibus-chef/pull/372

Manually test:
- [x] `knife-opc` related commands
- [x] `chef-client` related ctl commands

TODO:
- [x] Test is https://github.com/chef/knife-opc/issues/31 still exists in build with `knife-opc` 0.3.1. Close if not.
- [x] Resolve "looks like we need a new_record/5 function in the chef_key code for it to work with the new api version stuff" -SSD
- [x] Changelog

[Passing Build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/480/downstreambuildview/)

Ping @chef/lob 