### PR TITLE
Move chef-mover to master

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 11.16.2
+  require_chef_omnibus: 12.1.0
 
 platforms:
   - name: ubuntu-12.04
@@ -22,6 +22,8 @@ platforms:
     run_list: apt::default
   - name: centos-5.10
   - name: centos-6.5
+  - name: centos-7.0
+    run_list:  yum-epel::default
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -5,6 +5,7 @@ source 'https://api.berkshelf.com'
 cookbook 'apt', '~> 2.0'
 
 cookbook 'omnibus'
+cookbook 'yum-epel', '~> 0.6'
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
 # cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,6 +1,7 @@
 DEPENDENCIES
   apt (~> 2.0)
   omnibus
+  yum-epel (~> 0.6)
 
 GRAPH
   7-zip (1.0.2)
@@ -22,3 +23,6 @@ GRAPH
     chef_handler (>= 0.0.0)
   wix (1.1.0)
     windows (>= 1.2.2)
+  yum (3.5.4)
+  yum-epel (0.6.0)
+    yum (~> 3.0)

--- a/config/software/chef-server-bootstrap.rb
+++ b/config/software/chef-server-bootstrap.rb
@@ -19,7 +19,7 @@
 name "chef-server-bootstrap"
 default_version "1.0.1"
 
-source git: "git@github.com:opscode/chef-server-bootstrap"
+source git: "https://github.com/opscode/chef-server-bootstrap"
 
 dependency "ruby"
 dependency "libxml2"

--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -18,7 +18,7 @@ name "oc-chef-pedant"
 
 default_version "2.0.5"
 
-source git: "git@github.com:opscode/oc-chef-pedant.git"
+source git: "https://github.com/opscode/oc-chef-pedant"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/oc_bifrost.rb
+++ b/config/software/oc_bifrost.rb
@@ -17,7 +17,7 @@
 name "oc_bifrost"
 default_version "1.4.6"
 
-source git: "git@github.com:opscode/oc_bifrost"
+source git: "https://github.com/opscode/oc_bifrost"
 
 dependency "erlang"
 dependency "rebar"

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -18,7 +18,7 @@ name "oc_erchef"
 
 default_version "1.7.0"
 
-source git: "git@github.com:opscode/oc_erchef"
+source git: "https://github.com/opscode/oc_erchef"
 
 dependency "erlang"
 dependency "rebar"

--- a/config/software/oc_id.rb
+++ b/config/software/oc_id.rb
@@ -17,7 +17,7 @@
 name "oc_id"
 default_version "0.4.4"
 
-source git: "git@github.com:opscode/oc-id"
+source git: "https://github.com/opscode/oc-id"
 
 dependency "postgresql92" # for libpq
 dependency "nodejs"

--- a/config/software/opscode-chef-mover.rb
+++ b/config/software/opscode-chef-mover.rb
@@ -15,9 +15,9 @@
 #
 
 name "opscode-chef-mover"
-default_version "2.2.20"
+default_version "master"
 
-source git: "git@github.com:opscode/chef-mover"
+source git: "https://github.com/opscode/chef-mover"
 
 dependency "erlang"
 dependency "rebar"

--- a/config/software/opscode-expander.rb
+++ b/config/software/opscode-expander.rb
@@ -17,7 +17,7 @@
 name "opscode-expander"
 default_version "pc-rel-1.0.0.1"
 
-source git: "git@github.com:opscode/opscode-expander"
+source git: "https://github.com/opscode/opscode-expander"
 
 dependency "ruby"
 dependency "bundler"

--- a/files/private-chef-cookbooks/private-chef/Berksfile
+++ b/files/private-chef-cookbooks/private-chef/Berksfile
@@ -2,7 +2,7 @@ site :opscode
 
 metadata
 
-cookbook 'enterprise', :git => 'git@github.com:opscode-cookbooks/enterprise-chef-common.git', :tag => '0.5.1'
+cookbook 'enterprise', :git => 'https://github.com/opscode-cookbooks/enterprise-chef-common', :tag => '0.5.1'
 cookbook 'chef-ha-drbd', :path => '../chef-ha-drbd'
 cookbook 'apt', '~> 2.0'
 cookbook 'yum', '~> 3.0'


### PR DESCRIPTION
Moving chef-mover to master will help the eventual code merge as we are currently a few commits behind.  This is also required for RHEL7 builds.