### PR TITLE
Policies migration and enable

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -16,7 +16,7 @@
 
 name "oc-chef-pedant"
 
-default_version "2.1.0"
+default_version "2.2.0"
 
 source git: "https://github.com/opscode/oc-chef-pedant"
 

--- a/config/software/oc_erchef.rb
+++ b/config/software/oc_erchef.rb
@@ -16,7 +16,7 @@
 
 name "oc_erchef"
 
-default_version "1.8.2"
+default_version "1.8.3"
 
 source git: "https://github.com/opscode/oc_erchef"
 

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -289,7 +289,6 @@ default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = false
 default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = false
-default['private_chef']['lb']['xdl_defaults']['policies'] = false
 
 ####
 # Nginx

--- a/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/routes.lua.erb
@@ -73,13 +73,9 @@ local p_principals = P"principals"
 local p_internal_organizations_base = P"/internal-organizations"
 local p_controls = P"controls"
 local p_keys = P"keys"
--- template portion below prefixed with lua comment to prevent
--- errors when using un-rendered in tests.
--- <% if @xdl_defaults['policies'] %>
 local p_policyfile = P"policies"
 local p_policy_groups = P"policy_groups"
 local p_cookbook_artifacts = P"cookbook_artifacts"
--- <% end %>
 
 
 -- Composite patterns
@@ -120,12 +116,8 @@ local c_maybe_identifier = (p_sep * c_identifier)^-1
 
 local p_erchef_endpoint = p_cookbooks + p_data + p_roles + p_sandboxes +
                           p_environments + p_clients + p_nodes + p_principals +
-                          p_groups + p_containers + p_controls
--- template portion below prefixed with lua comment to prevent
--- errors when using un-rendered in tests.
--- <% if @xdl_defaults['policies'] %>
-                          + p_policy_groups + p_policyfile + p_cookbook_artifacts
--- <% end %>
+                          p_groups + p_containers + p_controls +
+                          p_policy_groups + p_policyfile + p_cookbook_artifacts
 
 
 -- endpoints that map directly to erchef

--- a/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -175,7 +175,7 @@ ruby_org_acl_endpoint?     false
 ruby_org_assoc?            false
 ruby_organizations_endpoint? false
 chef_12?                   true
-policies?                  <%= node['private_chef']['lb']['xdl_defaults']['policies'] %>
+policies?                  true
 search_acls?               <%= node['private_chef']['opscode-erchef']['strict_search_result_acls'] %>
 
 old_runlists_and_search true

--- a/files/private-chef-upgrades/001/023_policyfile_schema_and_permissions.rb
+++ b/files/private-chef-upgrades/001/023_policyfile_schema_and_permissions.rb
@@ -1,0 +1,28 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+
+    # We require the schema to at least contain the tag
+    # "policyfile-api-tables"; That tag comes _before_ "@cbv-type", which we
+    # upgraded to in 022_cbv_type_addition. Therefore we don't need to run any
+    # sqitch migration here.
+
+    # Make sure API is down
+    stop_services(["nginx", "opscode-erchef"])
+
+    start_services(["oc_bifrost", "postgresql"])
+
+    force_restart_service("opscode-chef-mover")
+
+    log "Creating default permissions for policyfile endpoints..."
+
+    run_command("/opt/opscode/embedded/bin/escript " +
+                "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
+                "mover_policies_containers_creation_callback " +
+                "normal " +
+                "mover_transient_queue_batch_migrator")
+
+    stop_services(["opscode-chef-mover"])
+  end
+end
+


### PR DESCRIPTION
* Includes partybus upgrade file to upgrade schema and run default ACL creation for policyfile endpoints
* enable policyfile endpoints by default in LB and pedant

@chef/lob