### PR TITLE
Update Java JRE to 8u31 from omnibus-software

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -32,7 +32,6 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
 override :ruby, version: "2.1.4"
-override :'server-jre', version: "7u25"
 
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
Per customer security request,  update to Java 8.  It's been in omnibus-software since https://github.com/chef/omnibus-software/pull/363