### PR TITLE
Support sending application statistics over the statsd protocol

### DIFF
--- a/config/software/oc_bifrost.rb
+++ b/config/software/oc_bifrost.rb
@@ -15,7 +15,7 @@
 #
 
 name "oc_bifrost"
-default_version "1.4.6"
+default_version "1.4.7"
 
 source git: "https://github.com/opscode/oc_bifrost"
 

--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -544,6 +544,7 @@ default['private_chef']['estatsd']['dir'] = "/var/opt/opscode/estatsd"
 default['private_chef']['estatsd']['log_directory'] = "/var/log/opscode/estatsd"
 default['private_chef']['estatsd']['vip'] = "127.0.0.1"
 default['private_chef']['estatsd']['port'] = 9466
+default['private_chef']['estatsd']['protocol'] = "estatsd"
 
 ##
 # Keepalived

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -101,6 +101,7 @@
          ]},
  {stats_hero, [
                 {udp_socket_pool_size, <%= node['private_chef']['postgresql']['max_connections'] %> },
+                {protocol, <%= node['private_chef']['estatsd']['protocol'] %>},
                 {estatsd_host, "<%= node['private_chef']['estatsd']['vip'] %>" },
                 {estatsd_port, <%= node['private_chef']['estatsd']['port'] %> }
                ]},

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -173,6 +173,7 @@
   {stats_hero, [
                %% Set sender pool size to DB max_connections to avoid contention
                {udp_socket_pool_size, <%= node['private_chef']['postgresql']['max_connections'] %> },
+               {protocol, <%= node['private_chef']['estatsd']['protocol'] %>},
                {estatsd_host, "<%= @helper.normalize_host(node['private_chef']['estatsd']['vip']) %>"},
                {estatsd_port, <%= node['private_chef']['estatsd']['port'] %>}
               ]},


### PR DESCRIPTION
Previous versions of Chef Server could only send application
statistics using the estatsd protocol.  This protocol is similar to
the statsd protocol but could not be parsed by standard statsd tools.
The newest versions of oc_erchef and oc_bifrost contains a new version
of our statistics collecting library, allowing users to send standard
statsd messages if they choose.

ChangeLog-Entry: Optionally send applications statistics over the
statsd protocol. Users who want to send statsd-formatted statistics
should set `estatsd['protocol'] = "statsd"` in their chef-server.rb
configuration file.