### PR TITLE
Move the cache_path into /var/opt/opscode to avoid warnings

### DIFF
--- a/config/software/private-chef-cookbooks.rb
+++ b/config/software/private-chef-cookbooks.rb
@@ -56,6 +56,7 @@ build do
     File.open("#{install_dir}/embedded/cookbooks/solo.rb", "w") do |f|
       f.write <<-EOH.gsub(/^ {8}/, '')
         cookbook_path   "#{install_dir}/embedded/cookbooks"
+        cache_path "/var/opt/opscode/local-mode-cache"
         file_cache_path "#{install_dir}/embedded/cookbooks/cache"
         verbose_logging true
         ssl_verify_mode :verify_peer

--- a/files/private-chef-upgrades/001/023_cleanup_local_cache_path.rb
+++ b/files/private-chef-upgrades/001/023_cleanup_local_cache_path.rb
@@ -1,0 +1,4 @@
+define_upgrade do
+  log "Removing /opt/opscode/embedded/cookbooks/local-mode-cache"
+  run_command("rm -rf /opt/opscode/embedded/cookbooks/local-mode-cache")
+end


### PR DESCRIPTION
Previously running reconfigure would yield many WARN-level messages
because the cache was embedded in the cookbook directory.  This moves
the cache to a more appropriate directory and cleans up the old cache
dir.

Fixes chef/chef-server#106

ChangeLog-Entry: Fix local-mode-cache warnings on `chef-server-ctl
reconfigure` (Issue #106)