### PR TITLE
add retry setting to folsom_graphite

### DIFF
--- a/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -598,8 +598,7 @@ default['private_chef']['upgrades']['dir'] = "/var/opt/opscode/upgrades"
 ##
 # Folsom Graphite
 ##
-# Off by default, graphite not included with chef. WARNING:If you turn on and
-# graphite is not available via tcp, erchef will fail to start.
+# Off by default, graphite not included with chef.
 default['private_chef']['folsom_graphite']['enabled'] = false
 # graphite server host name
 default['private_chef']['folsom_graphite']['host'] = "localhost"
@@ -609,3 +608,5 @@ default['private_chef']['folsom_graphite']['port'] = 8080
 default['private_chef']['folsom_graphite']['prefix'] = "stats_prefix"
 # how frequently to send stats to the graphite server in milliseconds
 default['private_chef']['folsom_graphite']['send_interval'] = 10000
+# if a connection fails, how frequently do we attempt to reconnect?
+default['private_chef']['folsom_graphite']['retry_interval'] = 2000

--- a/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -232,6 +232,7 @@
                      {graphite_port, <%= node['private_chef']['folsom_graphite']['port'] %>},
                      {graphite_prefix, "<%= node['private_chef']['folsom_graphite']['prefix'] %>"},
                      {send_interval, <%= node['private_chef']['folsom_graphite']['send_interval'] %>},
+                     {retry_interval, <%= node['private_chef']['folsom_graphite']['retry_interval'] %>},
                      {application, "erchef"}
                     ]
   }


### PR DESCRIPTION
Add retry_interval to folsom_graphite settings, and removed notice that having graphite unavailable would cause chef-server to fail, since with latest chef-server that's no longer true. 

This is by default now exposed as a tunable, though there's no much direct benefit to doing so. 