### PR TITLE
Minor logrotate configuration fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 12.1.0 (unknown)
 
+### private-chef-cookbooks/private-chef
+* Fix logrotate configuration to make it work with SELinux enabled.
+
 ### chef-client master
 * Server's install of Chef now floats on master.
 

--- a/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -184,7 +184,7 @@ template "/etc/opscode/logrotate.d/nginx" do
   group "root"
   mode "0644"
   variables(node['private_chef']['nginx'].to_hash.merge(
-    'postrotate' => "/opt/opscode/embedded/sbin/nginx -s reopen",
+    'postrotate' => "/opt/opscode/embedded/sbin/nginx -c #{nginx_config} -s reopen",
     'owner' => OmnibusHelper.new(node).ownership['owner'],
     'group' => OmnibusHelper.new(node).ownership['group']
   ))

--- a/files/private-chef-cookbooks/private-chef/templates/default/opc_logrotate.cron
+++ b/files/private-chef-cookbooks/private-chef/templates/default/opc_logrotate.cron
@@ -3,4 +3,4 @@
 PATH=/opt/opscode/embedded/sbin:$PATH
 
 command -v logrotate >/dev/null 2>&1 || exit 0
-nice -n 19 ionice -c3 logrotate /etc/opscode/logrotate.conf
+nice -n 19 ionice -c3 logrotate -s /var/log/chef/logrotate.status /etc/opscode/logrotate.conf


### PR DESCRIPTION
The following fixes in the logrotate configuration files allows to avoid issues on the boxes with  SELinux enabled.
