### PR TITLE
fix: correct the current org name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ changing the list found in the `.kitchen.yml` `platforms` YAML stanza.
 
 This build environment is designed to get you up-and-running quickly. However,
 there is nothing that restricts you to building on other platforms. Simply use
-the [omnibus cookbook](https://github.com/opscode-cookbooks/omnibus) to setup
+the [omnibus cookbook](https://github.com/chef-boneyard/omnibus) to setup
 your desired platform and execute the build steps listed above.
 
 The default build environment requires Test Kitchen and VirtualBox for local


### PR DESCRIPTION
either the whole readme should be refactored to not recommend use, or this needs to clearly reflect the guidance based on the current org name.